### PR TITLE
Supporting running tests on Windows

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
@@ -9,7 +9,7 @@ fi
 if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
   WEBOTS="webots"
 else
-  export PYTHONPATH="${WEBOTS_HOME}/projects/samples/contests/robocup/controllers/referee"
+  export PYTHONPATH="${WEBOTS_HOME}/projects/samples/contests/robocup/controllers/referee"  # this should be removed once https://github.com/cyberbotics/webots/issues/3011 is fixed
   WEBOTS="${WEBOTS_HOME}/webots"
 fi
 

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
@@ -9,6 +9,7 @@ fi
 if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
   WEBOTS="webots"
 else
+  export PYTHONPATH="${WEBOTS_HOME}/projects/samples/contests/robocup/controllers/referee"
   WEBOTS="${WEBOTS_HOME}/webots"
 fi
 

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
@@ -6,7 +6,12 @@ then
     exit -1
 fi
 
-WEBOTS="${WEBOTS_HOME}/webots"
+if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
+  WEBOTS="webots"
+else
+  WEBOTS="${WEBOTS_HOME}/webots"
+fi
+
 TEST_FOLDER="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 
 WEBOTS_ROBOCUP_TEST_SCENARIO="${TEST_FOLDER}/test_scenario.json" \

--- a/projects/samples/contests/robocup/controllers/test_supervisor/gamestate.py
+++ b/projects/samples/contests/robocup/controllers/test_supervisor/gamestate.py
@@ -1,1 +1,0 @@
-../referee/gamestate.py

--- a/projects/samples/contests/robocup/controllers/test_supervisor/runtime.ini
+++ b/projects/samples/contests/robocup/controllers/test_supervisor/runtime.ini
@@ -1,0 +1,2 @@
+[environment variable with relative paths]
+PYTHONPATH=$(WEBOTS_HOME)/projects/samples/contest/robocup/controllers/referee


### PR DESCRIPTION
This PR introduces a better way to reuse the `gamestate.py` module from the test_supervisor.
It also fixes the test launcher to support Windows.