### PR TITLE
Various fixes for forceful contact rules

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -973,13 +973,14 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
     v2 = p2['robot'].getVelocity()
     v1_squared = v1[0] * v1[0] + v1[1] * v1[1]
     v2_squared = v2[0] * v2[0] + v2[1] * v2[1]
-    if v1_squared > FOUL_SPEED_THRESHOLD * FOUL_SPEED_THRESHOLD:
-        if d1 < FOUL_VINCITY_DISTANCE:
-            if moves_to_ball(p2, v2, v2_squared):
-                if not moves_to_ball(p1, v1, v1_squared) or d1 - d2 > FOUL_DISTANCE_THRESHOLD:
-                    forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                          'opponent moving towards the ball')
-                    return True
+    if not v1_squared > FOUL_SPEED_THRESHOLD * FOUL_SPEED_THRESHOLD:
+        return False
+    if d1 < FOUL_VINCITY_DISTANCE:
+        if moves_to_ball(p2, v2, v2_squared):
+            if not moves_to_ball(p1, v1, v1_squared) or d1 - d2 > FOUL_DISTANCE_THRESHOLD:
+                forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
+                                      'opponent moving towards the ball')
+                return True
     elif math.sqrt(v1_squared) - math.sqrt(v2_squared) > FOUL_SPEED_THRESHOLD:
         forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'violent collision')
         return True

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1732,7 +1732,7 @@ game.interruption_team = None
 game.interruption_seconds = None
 game.dropped_ball = False
 game.overtime = False
-game.ready_countdown = 20 if game.minimum_real_time_factor == 0 else 1000000000000
+game.ready_countdown = 125 if game.minimum_real_time_factor == 0 else 1000000000000
 game.play_countdown = 0
 game.in_play = None
 game.sent_finish = False

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -44,7 +44,7 @@ SIMULATED_TIME_INTERRUPTION_PHASE_0 = 10  # waiting time of 10 simulated seconds
 SIMULATED_TIME_INTERRUPTION_PHASE_1 = 30  # waiting time of 30 simulated seconds in phase 1 of interruption
 SIMULATED_TIME_BEFORE_PLAY_STATE = 5      # wait 5 simulated seconds in SET state before sending the PLAY state
 SIMULATED_TIME_SET_PENALTY_SHOOTOUT = 15  # wait 15 simulated seconds in SET state before sending the PLAY state
-HALF_TIME_BREAK_SIMULATED_DURATION = 15   # the half-time break lasts 15 simulated seconds
+HALF_TIME_BREAK_REAL_TIME_DURATION = 15   # the half-time break lasts 15 real seconds
 REAL_TIME_BEFORE_FIRST_READY_STATE = 120  # wait 2 real minutes before sending the first READY state
 IN_PLAY_TIMEOUT = 10                      # time after which the ball is considered in play even if it was not kicked
 FALLEN_TIMEOUT = 20                       # if a robot is down (fallen) for more than this amount of time, it gets penalized
@@ -1460,7 +1460,7 @@ def next_penalty_shootout():
     info(f'fliped sides: game.side_left = {game.side_left}')
     set_penalty_positions()
     game_controller_send('STATE:SET')
-    game.play_countdown = SIMULATED_TIME_SET_PENALTY_SHOOTOUT
+    game.set_countdown = SIMULATED_TIME_SET_PENALTY_SHOOTOUT
     return
 
 
@@ -1738,13 +1738,14 @@ game.interruption_team = None
 game.interruption_seconds = None
 game.dropped_ball = False
 game.overtime = False
-game.ready_countdown = 125 if game.minimum_real_time_factor == 0 else 1000000000000
+game.set_countdown = 0  # simulated time countdown before set state (used in penalty shootouts)
+game.ready_countdown = 0  # simulated time countdown before ready state (used in kick-off after goal and ball dropped)
+game.ready_real_time = time.time() + REAL_TIME_BEFORE_FIRST_READY_STATE  # real time for ready state (used for initial kick-off)
 game.play_countdown = 0
 game.in_play = None
 game.sent_finish = False
 game.over = False
 game.wait_for_state = 'INITIAL'
-game.start_real_time = time.time()
 game.forceful_contact_matrix = ForcefulContactMatrix(len(red_team['players']), len(blue_team['players']),
                                                      FOUL_PUSHING_PERIOD, FOUL_PUSHING_TIME, time_step)
 
@@ -1893,11 +1894,12 @@ while supervisor.step(time_step) != -1 and not game.over:
                         info('End of knockout second half.')
                 else:
                     error(f'Unsupported game type: {game.type}.', fatal=True)
-        if game.interruption_countdown == 0 and game.ready_countdown == 0 and \
+        if (game.interruption_countdown == 0 and game.set_countdown == 0 and game.ready_countdown == 0 and
+            game.ready_real_time is None and
             (game.ball_position[1] - game.ball_radius >= game.field.size_y or
              game.ball_position[1] + game.ball_radius <= -game.field.size_y or
              game.ball_position[0] - game.ball_radius >= game.field.size_x or
-             game.ball_position[0] + game.ball_radius <= -game.field.size_x):
+             game.ball_position[0] + game.ball_radius <= -game.field.size_x)):
             info(f'Ball left the field at ({game.ball_position[0]} {game.ball_position[1]} {game.ball_position[2]}) after '
                  f'being touched by {game.ball_last_touch_team} player {game.ball_last_touch_player_number}.')
             game.ball_exit_translation = game.ball_position
@@ -1972,11 +1974,11 @@ while supervisor.step(time_step) != -1 and not game.over:
                 elif game.state.teams[i].players[game.ball_last_touch_player_number - 1].secs_till_unpenalized == 0:
                     game_controller_send(f'SCORE:{scoring_team}')
                     info(f'Score in {goal} goal by {game.ball_last_touch_team} player {game.ball_last_touch_player_number}')
-                    game.ready_countdown = SIMULATED_TIME_INTERRUPTION_PHASE_0
                     if game.penalty_shootout:
                         game.penalty_shootout_goal = True
                         next_penalty_shootout()
                     else:
+                        game.ready_countdown = SIMULATED_TIME_INTERRUPTION_PHASE_0
                         kickoff()
                 elif not right_way:  # own goal
                     game_controller_send(f'SCORE:{scoring_team}')
@@ -2027,7 +2029,7 @@ while supervisor.step(time_step) != -1 and not game.over:
         elif game.state.first_half:
             # NOTE: this part is probably dead code that is never used, transition from end of first Half to initial is
             #       now automatic.
-            if game.ready_countdown == 0:
+            if game.ready_real_time is None:
                 if game.overtime:
                     type = 'knockout '
                     game_controller_send('STATE:OVERTIME-SECOND-HALF')
@@ -2035,51 +2037,52 @@ while supervisor.step(time_step) != -1 and not game.over:
                     type = ''
                     game_controller_send('STATE:SECOND-HALF')
                 info(f'Beginning of {type}second half.')
-                game.ready_countdown = int(HALF_TIME_BREAK_SIMULATED_DURATION * game.real_time_multiplier)
+                game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
         elif game.type == 'KNOCKOUT' and game.overtime and game.state.teams[0].score == game.state.teams[1].score:
-            if game.ready_countdown == 0:
+            if game.ready_real_time is None:
                 info('Beginning of the knockout first half.')
                 game_controller_send('STATE:OVERTIME-FIRST-HALF')
-                game.ready_countdown = int(HALF_TIME_BREAK_SIMULATED_DURATION * game.real_time_multiplier)
+                game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
         elif game.type == 'KNOCKOUT' and game.state.teams[0].score == game.state.teams[1].score:
-            if game.ready_countdown == 0:
+            if game.ready_real_Time is None:
                 info('Beginning of penalty shout-out.')
                 game_controller_send('STATE:PENALTY-SHOOTOUT')
                 game.penalty_shootout = True
-                game.ready_countdown = int(HALF_TIME_BREAK_SIMULATED_DURATION * game.real_time_multiplier)
+                game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
         else:
             game.over = True
             break
 
     elif game.state.game_state == 'STATE_INITIAL':
-        if game.ready_countdown > 0:
-            game.ready_countdown -= 1
-            if game.penalty_shootout:
-                if game.ready_countdown == 0:
+        if game.penalty_shootout:
+            if game.set_countdown > 0:
+                game.set_countdown -= 1
+                if game.set_countdown == 0:
                     set_penalty_positions()
                     game_controller_send('STATE:SET')
-            elif time.time() - game.start_real_time > REAL_TIME_BEFORE_FIRST_READY_STATE or game.ready_countdown == 0:
+        elif game.ready_real_time is not None:
+            if game.ready_real_time <= time.time():  # initial kick-off (1st, 2nd half, extended periods, penalty shootouts)
+                game.ready_real_time = None
                 check_start_position()
                 game_controller_send('STATE:READY')
-                game.ready_countdown = 0
-        elif game.ready_countdown == 0 and not game.state.first_half:
+        elif game.ready_countdown > 0:
+            game.ready_countdown -= 1
+            if game.ready_countdown == 0:  # kick-off after goal or ball dropped
+                check_start_position()
+                game_controller_send('STATE:READY')
+        elif not game.state.first_half and game.sent_finish:
             game.sent_finish = False
-            game_type = ""
+            game_type = ''
             if game.overtime:
-                game_type = "overtime "
+                game_type = 'overtime '
             info(f'Beginning of {game_type} second half.')
             kickoff()
-            game.ready_countdown = int(HALF_TIME_BREAK_SIMULATED_DURATION * game.real_time_multiplier)
+            game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
 
     if game.interruption_countdown > 0:
         game.interruption_countdown -= 1
         if game.interruption_countdown == 0:
-            # TODO this first if should be useless now
-            if game.penalty_shootout:
-                next_penalty_shootout()
-                if game.over:
-                    break
-            elif game.ball_set_kick:
+            if game.ball_set_kick:
                 game.ball.resetPhysics()
                 game.ball_translation.setSFVec3f(game.ball_kick_translation)
                 game.ball_set_kick = False

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -974,9 +974,13 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
         return False
     if d1 < FOUL_VINCITY_DISTANCE:
         if moves_to_ball(p2, v2, v2_squared):
-            if not moves_to_ball(p1, v1, v1_squared) or d1 - d2 > FOUL_DISTANCE_THRESHOLD:
+            if not moves_to_ball(p1, v1, v1_squared):
                 forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                      'opponent moving towards the ball')
+                                      'opponent moving towards the ball, charge')
+                return True
+            if d1 - d2 > FOUL_DISTANCE_THRESHOLD:
+                forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
+                                      'opponent moving towards the ball, charge from behind')
                 return True
     elif math.sqrt(v1_squared) - math.sqrt(v2_squared) > FOUL_SPEED_THRESHOLD:
         forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'violent collision')

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -59,6 +59,7 @@ FOUL_VINCITY_DISTANCE = 2                 # 2 meters
 FOUL_DISTANCE_THRESHOLD = 0.1             # 0.1 meter
 FOUL_SPEED_THRESHOLD = 0.2                # 0.2 m/s
 FOUL_DIRECTION_THRESHOLD = math.pi / 6    # 30 degrees
+FOUL_BALL_DISTANCE = 1                    # if the ball is more than 1 m away from an offense, a removal penalty is applied
 LINE_WIDTH = 0.05                         # width of the white lines on the soccer field
 GOAL_WIDTH = 2.6                          # width of the goal
 RED_COLOR = 0xd62929                      # red team color used for the display
@@ -886,7 +887,7 @@ def forceful_contact_foul(team, number, opponent_team, opponent_number, distance
     info(f'{team["color"].capitalize()} player {number} committed a forceful contact foul on '
          f'{opponent_team["color"]} player {opponent_number} ({message}) {area}.')
     game.forceful_contact_matrix.clear_all()
-    if distance_to_ball > 1 or not game.in_play:
+    if distance_to_ball > FOUL_BALL_DISTANCE or not game.in_play:
         send_penalty(team['players'][number], 'INCAPABLE', 'forceful contact foul')
     elif area[0] == 'i':  # inside penalty area
         interruption('PENALTYKICK')

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -918,7 +918,7 @@ def forceful_contact_foul(team, number, opponent_team, opponent_number, distance
          f'{opponent_team["color"]} player {opponent_number} ({message}) {area}.')
     game.forceful_contact_matrix.clear_all()
     if distance_to_ball > FOUL_BALL_DISTANCE or not game.in_play:
-        send_penalty(team['players'][number], 'INCAPABLE', 'forceful contact foul')
+        send_penalty(team['players'][number], 'PHYSICAL_CONTACT', 'forceful contact foul')
     elif area[0] == 'i':  # inside penalty area
         interruption('PENALTYKICK')
     else:

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -888,7 +888,7 @@ def forceful_contact_foul(team, number, opponent_team, opponent_number, distance
          f'{opponent_team["color"]} player {opponent_number} ({message}) {area}.')
     game.forceful_contact_matrix.clear_all()
     if distance_to_ball > FOUL_BALL_DISTANCE or not game.in_play:
-        send_penalty(team['players'][number], 'INCAPABLE', 'forceful contact foul')
+        send_penalty(team['players'][number], 'PHYSICAL_CONTACT', 'forceful contact foul')
     elif area[0] == 'i':  # inside penalty area
         interruption('PENALTYKICK')
     else:

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -93,8 +93,11 @@ def log(message, type):
         console_message = message
     print(console_message, file=sys.stderr if type == 'Error' else sys.stdout)
     if log_file:
-        real_time = int(1000 * (time.time() - game.start_real_time)) / 1000
+        real_time = int(1000 * (time.time() - log.real_time)) / 1000
         log_file.write(f'[{real_time:08.3f}|{time_count / 1000:08.3f}] {type}: {message}\n')  # log real and virtual times
+
+
+log.real_time = time.time()
 
 
 def info(message):
@@ -1579,7 +1582,6 @@ with open(game.blue.config) as json_file:
     blue_team = json.load(json_file)
 
 # finalize the game object
-game.start_real_time = time.time()
 if not hasattr(game, 'minimum_real_time_factor'):
     game.minimum_real_time_factor = 3  # we garantee that each time step lasts at least 3x simulated time
 if not hasattr(game, 'press_a_key_to_terminate'):
@@ -1742,6 +1744,7 @@ game.in_play = None
 game.sent_finish = False
 game.over = False
 game.wait_for_state = 'INITIAL'
+game.start_real_time = time.time()
 game.forceful_contact_matrix = ForcefulContactMatrix(len(red_team['players']), len(blue_team['players']),
                                                      FOUL_PUSHING_PERIOD, FOUL_PUSHING_TIME, time_step)
 

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/charging/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/charging/test_scenario.json
@@ -122,7 +122,7 @@
     },
     {
         "timing" : {
-            "time" : [23.0, 30.0],
+            "time" : [27.0, 30.0],
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/README.md
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/README.md
@@ -1,0 +1,39 @@
+# Forceful contact - competing for the ball
+
+## Introduction
+
+This situation include 4 variations: A,B,C. When they differ, it is explicitly
+specified.
+
+A. Both players move toward the ball, distance to ball is similar (diff < 0.1m) -> no foul
+B. Both players move toward the ball, R1 is signicantly closer -> R2 commits a foul
+C. R1 is static, closer to the ball, R2 move towards the ball from behind and
+   collide -> R2 commits a foul
+
+## Setup:
+
+- GameState is READY and ball is in play
+- Robots R1 and R2 are nearby, they are of opposite team, not penalized and
+  outside any penalty area. They move approximately at the speed indicated by
+  the table below.
+- The ball is placed relatively close to the robots, ensuring that at
+  the collision time, the distance to the robots is approximately `Dist` as
+  provided below.
+  
+| Variation | R1 speed [m/s] | R2 speed [m/s] | Dist [m] |
+|-----------|----------------|----------------|----------|
+| A         |            0.3 |            0.3 |      1.5 |
+| B         |            0.4 |            0.4 |      1.5 |
+| C         |            0.0 |            0.5 |      1.5 |
+
+## Expected outcome
+
+- A. No freekick, no penalties
+- B. R2 is penalized, R1 is not penalized
+- C. R2 is penalized, R1 is not penalized
+
+## Notes:
+
+While 'A' is passing, it is very sensitive to initial position because after the
+first tick of collision between the robots, the trajectories of the robot can
+change

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/game.json
@@ -1,0 +1,43 @@
+{
+  "type": "NORMAL",
+  "class": "KID",
+  "side_left": "red",
+  "kickoff": "blue",
+  "supervisor": "test_supervisor",
+  "host": "192.168.1.133",
+  "minimum_real_time_factor": 0,
+  "red": {
+    "id": 9,
+    "config": "tests/forceful_contact/competing_for_ball/team_1.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.21",
+      "192.168.123.22",
+      "192.168.123.23",
+      "192.168.123.24"
+    ],
+    "ports": [
+      10001,
+      10002,
+      10003,
+      10004
+    ]
+  },
+  "blue": {
+    "id": 7,
+    "config": "tests/forceful_contact/competing_for_ball/team_2.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.41",
+      "192.168.123.42",
+      "192.168.123.43",
+      "192.168.123.44"
+    ],
+    "ports": [
+      10021,
+      10022,
+      10023,
+      10024
+    ]
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/team_1.json
@@ -1,0 +1,24 @@
+{
+  "name": "Funny Dingos",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, 3.11, 0.24],
+        "rotation": [0, 0, 1, -1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, -1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/team_2.json
@@ -1,0 +1,24 @@
+{
+  "name": "Agile Lynxes",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/competing_for_ball/test_scenario.json
@@ -1,0 +1,256 @@
+[
+    {
+        "description" : "Moving robots so they are not penalized on SET",
+        "timing" : {
+            "time" : 10.0,
+            "clock_type" : "Simulated",
+            "state" : "READY"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-1.4, 1.0, 0.24]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [2.0, 1.2, 0.24]
+            }
+        ]
+    },
+    {
+        "description" : "Part A. Moving robots for theoretical impact at [0.0,0.0]",
+        "timing" : {
+            "time" : 11.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [0.0, 1.5, 0.08]
+            },
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-0.28, -1.22, 0.3],
+                "orientation" : [0,0,1,1.57]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [0.28, -1.2, 0.3],
+                "orientation" : [0,0,1,1.57]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [11.001, 14.2],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "velocity" : [0.05, 0.3, 0.24]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "velocity" : [-0.05,0.3, 0.24]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [15.0, 20.0],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "A. Competing for the ball at similar distance -> Normal state",
+                "secondary_state" : "NORMAL"
+            },
+            {
+                "name" : "A. Competing for ball at similar distance -> No penalty (1)",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "A. Competing for ball at similar distance -> No penalty (2)",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
+            }
+        ]
+    },
+    {
+        "description" : "Part A. end: avoiding fallen robot penalty",
+        "timing" : {
+            "time" : 25.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [0.0, 1.5, 0.08]
+            },
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-4.8, -1.5, 0.24],
+                "orientation" : [0,0,1,1.57]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [4.8, -1.5, 0.24],
+                "orientation" : [0,0,1,1.57]
+            }
+        ]
+    },
+    {
+        "description" : "Part B. Moving robots for theoretical impact at [1.0,0.5]",
+        "timing" : {
+            "time" : 60.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [-0.5, 0.5, 0.08]
+            },
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [2.6, 0.5, 0.3],
+                "orientation" : [0,0,1,3.14]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [2.7, 0, 0.3],
+                "orientation" : [0,0,1,3.14]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [60.001, 63.5],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "velocity" : [-0.4, 0.0, 0.24]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "velocity" : [-0.4,0.08, 0.24]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [65.0, 70.0],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "B. Competing for the ball far from ball -> Normal state",
+                "secondary_state" : "NORMAL"
+            },
+            {
+                "name" : "B. Competing for ball, closest player -> No penalty",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "B. Competing for ball at similar distance -> Penalized",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 31
+            }
+        ]
+    },
+    {
+        "description" : "Part B. end: avoiding fallen robot penalty",
+        "timing" : {
+            "time" : 75.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [0.0, 1.5, 0.08]
+            },
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-4.8, -1.5, 0.24],
+                "orientation" : [0,0,1,1.57]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [4.8, -1.5, 0.24],
+                "orientation" : [0,0,1,1.57]
+            }
+        ]
+    },
+    {
+        "description" : "Part C. Moving robots for theoretical impact at [0.0,1.0]",
+        "timing" : {
+            "time" : 100.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [0.0, 2.5, 0.08]
+            },
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [0.0, 1.0, 0.24],
+                "orientation" : [0,0,1,1.57]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [0.0, -1.0, 0.3],
+                "orientation" : [0,0,1,3.14]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [100.001, 103.8],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BLUE_PLAYER_1",
+                "velocity" : [0,0.5, 0.24]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [105.0, 110.0],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "C. Charge from behind far from ball -> Normal state",
+                "secondary_state" : "NORMAL"
+            },
+            {
+                "name" : "C. Charged by behind while static -> No penalty",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "C. Charging a static robot by behind -> Penalized",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 31
+            }
+        ]
+    }
+]

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/initial/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/initial/test_scenario.json
@@ -1,7 +1,7 @@
 [
     {
         "timing" : {
-            "time" : [1.0, 119.0],
+            "time" : [1.0, 118.0],
             "clock_type" : "System"
         },
         "tests" : [
@@ -13,7 +13,7 @@
     },
     {
         "timing" : {
-            "time" : 125.0,
+            "time" : 122.0,
             "clock_type" : "System"
         },
         "tests" : [

--- a/projects/samples/contests/robocup/controllers/referee/tests/positioning/initial/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/positioning/initial/test_scenario.json
@@ -1,13 +1,13 @@
 [
     {
         "timing" : {
-            "time" : [1.0, 4.0],
+            "time" : [0.1, 0.5],
             "clock_type" : "Simulated",
             "state" : "INITIAL"
         },
         "tests" : [
             {
-                "name" : "Staying in INITIAL for a few seconds",
+                "name" : "Staying in INITIAL",
                 "state" : "INITIAL"
             },
             {

--- a/projects/samples/contests/robocup/controllers/referee/tests/positioning/ready/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/positioning/ready/test_scenario.json
@@ -1,13 +1,13 @@
 [
     {
         "timing" : {
-            "time" : [1.0, 4.0],
+            "time" : [0.1, 0.5],
             "clock_type" : "Simulated",
             "state" : "INITIAL"
         },
         "tests" : [
             {
-                "name" : "Staying in INITIAL for a few seconds",
+                "name" : "Staying in INITIAL",
                 "state" : "INITIAL"
             }
         ]

--- a/projects/samples/contests/robocup/controllers/referee/tests/results/draw/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/results/draw/test_scenario.json
@@ -372,11 +372,25 @@
         ]
     },
     {
-        "description" : "testing transition to READY directly because time spent in INITIAL is too low",
         "timing" : {
-            "time" : 610,
+            "time" : 605,
             "clock_type" : "Simulated",
             "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "Automatic transition to 1st Half PLAYING -> 2nd half INITIAL",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 3,
+            "clock_type" : "System",
+            "state" : "INITIAL",
+            "state_count" : 2
         },
         "tests" : [
             {

--- a/projects/samples/contests/robocup/controllers/referee/tests/results/win/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/results/win/test_scenario.json
@@ -246,9 +246,24 @@
     },
     {
         "timing" : {
-            "time" : 610,
+            "time" : 605,
             "clock_type" : "Simulated",
             "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "Automatic transition to 1st Half PLAYING -> 2nd half INITIAL",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 3,
+            "clock_type" : "System",
+            "state" : "INITIAL",
+            "state_count" : 2
         },
         "tests" : [
             {


### PR DESCRIPTION
- [x] 1. At L484 of the rule book (right after the ball holding), it is stated that "if an offense did not happen within a radius of approx. 1m around the current ball position or if the ball is not in play, the direct free kick is replaced by a removal penalty". This applies to forceful contact as well.

- [x] 2. Since the ball is out of play during a freekick, it is impossible to start a freekick during another freekick. In this case, removal penalty should be applied. In the current implementation, freekick is called at every tick until the collision stops which has as consequence a major slowdown of the simulation since the Referee is waiting for the GameController to answer after every directkick request. It is very difficult to fix the test_scenarios with this behavior.

- [x] 3. Problem 2 makes it pretty clear that we will need an 'immunity duration' once a forceful contact has been detected, otherwise the robot that triggered the freekick is likely to receive a removal penalty on the following tick. I think that 2 seconds would be a good value to start this implementation.

- [x] 4. It is quite critical to refactor the 'check_forceful_contact' function. It is a symmetrical problem, therefore duplicating the code is much more likely to lead to bugs and much harder to maintain than simply calling: analyze_forceful_contact(team_1,number_1, team_2, number_2) and then analyze_forceful_contact(team_2,number_2,team_1,number_1).