### PR TITLE
Fix robocup player controller select() error detection

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/player.cpp
+++ b/projects/samples/contests/robocup/controllers/player/player.cpp
@@ -302,7 +302,7 @@ public:
     while (received < length) {
       int n = recv(client_fd, buffer, length - received, 0);
       if (n == -1) {
-        if (errno != EAGAIN || errno != EWOULDBLOCK) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
           perror("recv()");
           printMessage("Unexpected failure while receiving data");
           close_socket(client_fd);


### PR DESCRIPTION
This bug is more of theoretical nature.
The statement `e != EAGAIN || e!= EWOULDBLOCK` is always true if `EAGAIN
!= EWOULDBLOCK`. In practice EAGAIN and EWOULDBLOCK have the same value.
To keep confusion away this PR corrects this statement.
