### PR TITLE
Fix Crash on invalid time_step value

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/player.cpp
+++ b/projects/samples/contests/robocup/controllers/player/player.cpp
@@ -415,27 +415,27 @@ public:
         else
           switch (device->getNodeType()) {
             case webots::Node::ACCELEROMETER: {
-              webots::Accelerometer *accelerometer = (webots::Accelerometer *)device;
+              webots::Accelerometer *accelerometer = static_cast<webots::Accelerometer *>(device);
               accelerometer->enable(sensor_time_step);
               break;
             }
             case webots::Node::CAMERA: {
-              webots::Camera *camera = (webots::Camera *)device;
+              webots::Camera *camera = static_cast<webots::Camera *>(device);
               camera->enable(sensor_time_step);
               break;
             }
             case webots::Node::GYRO: {
-              webots::Gyro *gyro = (webots::Gyro *)device;
+              webots::Gyro *gyro = static_cast<webots::Gyro *>(device);
               gyro->enable(sensor_time_step);
               break;
             }
             case webots::Node::POSITION_SENSOR: {
-              webots::PositionSensor *positionSensor = (webots::PositionSensor *)device;
+              webots::PositionSensor *positionSensor = static_cast<webots::PositionSensor *>(device);
               positionSensor->enable(sensor_time_step);
               break;
             }
             case webots::Node::TOUCH_SENSOR: {
-              webots::TouchSensor *touchSensor = (webots::TouchSensor *)device;
+              webots::TouchSensor *touchSensor = static_cast<webots::TouchSensor *>(device);
               touchSensor->enable(sensor_time_step);
               break;
             }


### PR DESCRIPTION
This PR consist of two commits:
1. Small cleanup and replacing C-Casts with dynamic_casts.
2. Fixing crashes on invalid time_step_size. The issue is when sending invalid time_step via the client the player controller crashes.
  Although the time_step is invalid the sensors gets activated and inserted into the `new_sensors` list, which causes division
  by 0 errors later in the code
This PR fixes this.

