### PR TITLE
Fixed player and sample client

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/actuator_requests.txt
+++ b/projects/samples/contests/robocup/controllers/player/actuator_requests.txt
@@ -4,7 +4,7 @@ motor_positions {
 }
 motor_positions {
   name: "Head"
-  position: 1.8
+  position: 0.8
 }
 sensor_time_steps {
   name: "NeckS"

--- a/projects/samples/contests/robocup/controllers/player/player.cpp
+++ b/projects/samples/contests/robocup/controllers/player/player.cpp
@@ -331,7 +331,7 @@ public:
     while (received < length) {
       int n = recv(client_fd, buffer, length - received, 0);
       if (n == -1) {
-        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        if (errno && errno != EAGAIN && errno != EWOULDBLOCK) {
           perror("recv()");
           printMessage("Unexpected failure while receiving data");
           closeClientSocket();


### PR DESCRIPTION
This PR fixes:
- a wrong command (motor position out of range) causing a repeated warning flooding the Webots console.
- the execution of the player controller on Windows where `errno` is set to 0 instead of `EAGAIN` or `EWOULDBLOCK`.