### PR TITLE
Fixed compilation of sample client on Linux, simplified Makefile for player

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/Makefile
+++ b/projects/samples/contests/robocup/controllers/player/Makefile
@@ -20,9 +20,7 @@
 null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
-RESOURCES_PATH = $(WEBOTS_HOME)/projects/robots/robotis/darwin-op
-INCLUDE = -I"$(RESOURCES_PATH)/libraries/managers/include" -I"$(RESOURCES_PATH)/libraries/robotis-op2/robotis/Framework/include"
-LIBRARIES = -L"$(RESOURCES_PATH)/libraries/robotis-op2" -lrobotis-op2 -L"$(RESOURCES_PATH)/libraries/managers" -lmanagers -lprotobuf -ljpeg
+LIBRARIES = -lprotobuf -ljpeg
 CXX_SOURCES = player.cpp messages.pb.cpp
 CFLAGS = -Wno-array-bounds
 FILES_TO_REMOVE = messages.pb.* client.exe client

--- a/projects/samples/contests/robocup/controllers/player/Makefile.client
+++ b/projects/samples/contests/robocup/controllers/player/Makefile.client
@@ -4,7 +4,7 @@ LIBS = -lws2_32
 CXX=g++
 else
 TARGET = client
-LIBS =
+LIBS = -lpthread
 endif
 ifeq ($(MAKECMDGOALS),)
 GOAL = release


### PR DESCRIPTION
libpthread is apparently needed for protobuf to work properly otherwise it produces a strange runtime crash.