### PR TITLE
RoboCup default client refactor

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/Makefile
+++ b/projects/samples/contests/robocup/controllers/player/Makefile
@@ -21,7 +21,7 @@ null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 LIBRARIES = -lprotobuf -ljpeg
-CXX_SOURCES = player.cpp messages.pb.cpp
+CXX_SOURCES = player.cpp messages.pb.cpp robot_client.cpp
 CFLAGS = -Wno-array-bounds
 FILES_TO_REMOVE = messages.pb.* client.exe client
 ifeq ($(OS),Windows_NT)

--- a/projects/samples/contests/robocup/controllers/player/Makefile
+++ b/projects/samples/contests/robocup/controllers/player/Makefile
@@ -21,7 +21,7 @@ null :=
 space := $(null) $(null)
 WEBOTS_HOME_PATH=$(subst $(space),\ ,$(strip $(subst \,/,$(WEBOTS_HOME))))
 LIBRARIES = -lprotobuf -ljpeg
-CXX_SOURCES = player.cpp messages.pb.cpp robot_client.cpp
+CXX_SOURCES = player.cpp messages.pb.cpp
 CFLAGS = -Wno-array-bounds
 FILES_TO_REMOVE = messages.pb.* client.exe client
 ifeq ($(OS),Windows_NT)
@@ -38,7 +38,7 @@ defaut: release
 
 release debug profile: clients
 
-clients: build/$(GOAL)/messages.pb.o
+clients: build/$(GOAL)/messages.pb.o messages.pb.h
 	$(MAKE) -f Makefile.client $(MAKECMDGOALS)
 
 messages.pb.cpp message.pb.h:	messages.proto

--- a/projects/samples/contests/robocup/controllers/player/Makefile.client
+++ b/projects/samples/contests/robocup/controllers/player/Makefile.client
@@ -18,8 +18,8 @@ LIBS += -lprotobuf
 
 build release debug profile: $(TARGET)
 
-$(TARGET): client.cpp
-	$(CXX) $< build/$(GOAL)/messages.pb.o -o $@ $(LIBS)
+$(TARGET): client.cpp build/$(GOAL)/messages.pb.o build/$(GOAL)/robot_client.o
+	$(CXX) $^  -o $@ $(LIBS)
 
 clean:
 	rm -f client.o client client.exe

--- a/projects/samples/contests/robocup/controllers/player/Makefile.client
+++ b/projects/samples/contests/robocup/controllers/player/Makefile.client
@@ -18,6 +18,9 @@ LIBS += -lprotobuf
 
 build release debug profile: $(TARGET)
 
+build/$(GOAL)/robot_client.o:
+	$(CXX) robot_client.cpp -c -o $@
+
 $(TARGET): client.cpp build/$(GOAL)/messages.pb.o build/$(GOAL)/robot_client.o
 	$(CXX) $^  -o $@ $(LIBS)
 

--- a/projects/samples/contests/robocup/controllers/player/actuator_requests.txt
+++ b/projects/samples/contests/robocup/controllers/player/actuator_requests.txt
@@ -10,3 +10,7 @@ sensor_time_steps {
   name: "NeckS"
   timeStep: 8
 }
+sensor_time_steps {
+  name: "Camera"
+  timeStep: 16
+}

--- a/projects/samples/contests/robocup/controllers/player/client.cpp
+++ b/projects/samples/contests/robocup/controllers/player/client.cpp
@@ -16,17 +16,6 @@
 #include <string.h>
 #include <iostream>
 
-#ifdef _WIN32
-#include <winsock.h>
-#else
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
-#endif
-
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>
 #include "messages.pb.h"
@@ -34,158 +23,60 @@
 #define ByteSizeLong ByteSize
 #endif
 
-static void close_socket(int fd) {
-#ifdef _WIN32
-  closesocket(fd);
-#else
-  close(fd);
-#endif
-}
+#include "robot_client.hpp"
 
-static char *read_file(const char *filename) {
-  char *buffer = NULL;
-  FILE *fp = fopen(filename, "r");
-  if (!fp)
-    return NULL;
-  if (fseek(fp, 0L, SEEK_END) == 0) {
-    const long size = ftell(fp);
-    assert(size != -1);
-    buffer = (char *)malloc(sizeof(char) * (size + 1));
-    fseek(fp, 0L, SEEK_SET);
-    const size_t len = fread(buffer, sizeof(char), size, fp);
-    buffer[len] = '\0';
-  }
-  fclose(fp);
-  return buffer;
-}
-
-static void socket_closed_exit() {
-  printf("Connection closed by server.\n");
-  exit(1);
+static void usage(const std::string &error_msg = "") {
+  if (error_msg.length() > 0)
+    fprintf(stderr, "Invalid call: %s\n", error_msg.c_str());
+  fprintf(stderr, "Usage: client [-v verbosity_level] <host> <port>\n");
 }
 
 int main(int argc, char *argv[]) {
-  struct sockaddr_in address;
-  struct hostent *server;
-  int fd, rc;
-  char *buffer;
-  int port = 10003;
-  char host[256];  // localhost
-
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  sprintf(host, "127.0.0.1");
-  if (argc > 1) {
-    if (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0) {
-      printf("Usage: client <IP:port> or <IP> or <port>\n");
-      return 0;
-    }
-    const char *n = strchr(argv[1], ':');
-    if (n > 0) {
-      port = atoi(n + 1);
-      strncpy(host, argv[1], sizeof(host) - 1);
-      host[n - argv[1]] = '\0';
-    } else if (strchr(argv[1], '.') || !isdigit(argv[1][0]))
-      strncpy(host, argv[1], sizeof(host) - 1);
-    else
-      port = atoi(argv[1]);
-  }
-#ifdef _WIN32
-  WSADATA info;
-  rc = WSAStartup(MAKEWORD(2, 2), &info);  // Winsock 2.2
-  if (rc != 0) {
-    fprintf(stderr, "Cannot initialize Winsock\n");
-    return 1;
-  }
-#endif
-  fd = socket(AF_INET, SOCK_STREAM, 0);
-  if (fd == -1) {
-    fprintf(stderr, "Cannot create socket\n");
-    return 1;
-  }
-  memset(&address, 0, sizeof(struct sockaddr_in));
-  address.sin_family = AF_INET;
-  address.sin_port = htons(port);
-  server = gethostbyname(host);
-
-  if (server)
-    memcpy((char *)&address.sin_addr.s_addr, (char *)server->h_addr, server->h_length);
-  else {
-    fprintf(stderr, "Cannot resolve server name: %s\n", host);
-    close_socket(fd);
-    return 1;
-  }
-  rc = connect(fd, (struct sockaddr *)&address, sizeof(struct sockaddr));
-  if (rc == -1) {
-    fprintf(stderr, "Cannot connect to %s:%d\n", host, port);
-    close_socket(fd);
-    return 1;
-  }
-  char answer[8];
-  int n = recv(fd, answer, sizeof(answer), 0);
-  if (n > 0) {
-    if (strncmp(answer, "Welcome", 8) != 0) {
-      if (strncmp(answer, "Refused", 8) == 0)
-        printf("Connection to %s:%d refused: your IP address is not allowed in the game.json configuration file.\n", host,
-               port);
+  int port = -1;
+  std::string host;
+  int arg_idx = 1;
+  int verbosity = 3;
+  while (arg_idx < argc) {
+    std::string current_arg(argv[arg_idx]);
+    // Treating arguments
+    if (current_arg[0] == '-') {
+      if (current_arg == "-v") {
+        if (arg_idx + 1 >= argc)
+          usage("Missing value for verbosity");
+        verbosity = std::stoi(argv[arg_idx + 1]);
+        arg_idx++;
+      } else if (current_arg == "-h" || current_arg == "--help")
+        usage();
       else
-        printf("Received unknown answer from server: %s\n", answer);
-      return 1;
-    }
-  } else {
-    printf("Connection closed.\n");
-    return 1;
+        usage();
+    } else if (host.length() == 0)
+      host = current_arg;
+    else if (port == -1) {
+      port = std::stoi(current_arg);
+      if (port < 0)
+        usage("Unexpected negative value for port: " + current_arg);
+    } else
+      usage("Unexpected additional argument: " + current_arg);
+    arg_idx++;
   }
-  printf("Connected to %s:%d\n", host, port);
-  for (;;) {
-    const char *message = read_file("actuator_requests.txt");
-    printf("Message = %s\n", message);
+  if (port == -1)
+    usage("Missing arguments");
 
-    ActuatorRequests actuatorRequests;
-    google::protobuf::TextFormat::ParseFromString(message, &actuatorRequests);
-#ifndef _WIN32
-    // This doesn't work on Windows, we should implement SocketOutputStream to make it work efficiently on Windows
-    // See https://stackoverflow.com/questions/23280457/c-google-protocol-buffers-open-http-socket
-    const int size = htonl(actuatorRequests.ByteSizeLong());
-    if (send(fd, (char *)(&size), sizeof(int), 0) == -1)
-      socket_closed_exit();
-    google::protobuf::io::ZeroCopyOutputStream *zeroCopyStream = new google::protobuf::io::FileOutputStream(fd);
-    actuatorRequests.SerializeToZeroCopyStream(zeroCopyStream);
-    delete zeroCopyStream;
-#else  // here we make a useless malloc, copy and free
-    const int size = actuatorRequests.ByteSizeLong();
-    char *output = (char *)malloc(sizeof(int) + size);
-    int *output_size = (int *)output;
-    *output_size = htonl(size);
-    actuatorRequests.SerializeToArray(&output[sizeof(int)], size);
-    if (send(fd, output, sizeof(int) + size, 0) == -1) {
-      free(output);
-      socket_closed_exit();
+  RobotClient client(host, port, verbosity);
+  client.connectClient();
+  while (client.isOk()) {
+    try {
+      ActuatorRequests request = RobotClient::buildRequestMessage("actuator_requests.txt");
+      client.sendRequest(request);
+      SensorMeasurements sensors = client.receive();
+      std::string printout;
+      google::protobuf::TextFormat::PrintToString(sensors, &printout);
+    } catch (const std::runtime_error &exc) {
+      std::cerr << "Connection closed automatically on the following exception: " << exc.what() << std::endl;
     }
-    free(output);
-#endif
-    int s;
-    if (recv(fd, (char *)&s, sizeof(int), 0) == -1)
-      socket_closed_exit();
-    const int answer_size = ntohl(s);
-    SensorMeasurements sensorMeasurements;
-    if (answer_size) {
-      buffer = (char *)malloc(answer_size);
-      int i = 0;
-      while (i < answer_size) {
-        n = recv(fd, &buffer[i], answer_size, 0);
-        if (n == -1)
-          socket_closed_exit();
-        i += n;
-      }
-      sensorMeasurements.ParseFromArray(buffer, answer_size);
-      free(buffer);
-    }
-    std::string printout;
-    google::protobuf::TextFormat::PrintToString(sensorMeasurements, &printout);
-    std::cout << printout << std::endl;
   }
-  close_socket(fd);
-  printf("Connection closed.\n");
+
   return 0;
 }

--- a/projects/samples/contests/robocup/controllers/player/robot_client.cpp
+++ b/projects/samples/contests/robocup/controllers/player/robot_client.cpp
@@ -1,0 +1,248 @@
+#include "robot_client.hpp"
+
+#ifdef _WIN32
+#include <winsock.h>
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+#include <cmath>
+#include <stdexcept>
+
+float RobotClient::history_period = 5;
+int RobotClient::max_answer_size = 1920 * 1080 * 3 + 1000;  // Adding some margin for other data than image
+int RobotClient::max_attempts = 20;
+int RobotClient::wait_time_sec = 1;
+
+static void close_socket(int fd) {
+#ifdef _WIN32
+  closesocket(fd);
+#else
+  close(fd);
+#endif
+}
+
+static char *read_file(const char *filename) {
+  char *buffer = NULL;
+  FILE *fp = fopen(filename, "r");
+  if (!fp)
+    return NULL;
+  if (fseek(fp, 0L, SEEK_END) == 0) {
+    const long size = ftell(fp);
+    assert(size != -1);
+    buffer = (char *)malloc(sizeof(char) * (size + 1));
+    fseek(fp, 0L, SEEK_SET);
+    const size_t len = fread(buffer, sizeof(char), size, fp);
+    buffer[len] = '\0';
+  }
+  fclose(fp);
+  return buffer;
+}
+
+RobotClient::RobotClient(const std::string &host, int port, int verbosity) :
+  host(host),
+  port(port),
+  socket_fd(-1),
+  verbosity(verbosity),
+  history_total_size(0),
+  client_start(0),
+  last_history_print(0) {
+}
+
+bool RobotClient::connectClient() {
+  int return_code;
+  struct hostent *server = gethostbyname(host.c_str());
+  struct sockaddr_in address;
+  memset(&address, 0, sizeof(struct sockaddr_in));
+  address.sin_family = AF_INET;
+  address.sin_port = htons(port);
+  if (server)
+    memcpy((char *)&address.sin_addr.s_addr, (char *)server->h_addr, server->h_length);
+  else {
+    fprintf(stderr, "Cannot resolve server name: %s\n", host.c_str());
+    return false;
+  }
+#ifdef _WIN32
+  WSADATA info;
+  return_code = WSAStartup(MAKEWORD(2, 2), &info);  // Winsock 2.2
+  if (return_code != 0) {
+    if (verbosity > 0)
+      fprintf(stderr, "Cannot initialize Winsock\n");
+    return false;
+  }
+#endif
+  socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (socket_fd == -1) {
+    if (verbosity > 0)
+      fprintf(stderr, "Cannot create socket\n");
+    return false;
+  }
+  int attempt = 1;
+  bool connected = false;
+  while (attempt <= max_attempts) {
+    return_code = connect(socket_fd, (struct sockaddr *)&address, sizeof(struct sockaddr));
+    if (return_code == 0) {
+      connected = true;
+      break;
+    }
+    fprintf(stderr, "Failed to connect to %s:%d (attempt %d / %d)\n", host.c_str(), port, attempt, max_attempts);
+    attempt++;
+    sleep(wait_time_sec);
+  }
+  if (!connected) {
+    if (verbosity > 0) {
+      fprintf(stderr, "Failed to connect after %d attempts. Giving up on connection\n", attempt);
+    }
+    disconnectClient();
+    return false;
+  }
+  // Receiving the 'welcome message'
+  char answer[8];
+  receiveData(answer, 8);
+  if (strncmp(answer, "Welcome", 8) != 0) {
+    if (verbosity > 0) {
+      if (strncmp(answer, "Refused", 8) == 0)
+        fprintf(stderr, "Connection to %s:%d refused: your IP address is not allowed in the game.json configuration file.\n",
+                host.c_str(), port);
+      else
+        fprintf(stderr, "Received unknown answer from server: %s\n", answer);
+    }
+    disconnectClient();
+    return false;
+  }
+  if (verbosity >= 2)
+    printf("Connected to %s:%d\n", host.c_str(), port);
+  return true;
+}
+
+void RobotClient::disconnectClient() {
+  if (socket_fd == -1 && verbosity > 0) {
+    fprintf(stderr, "RobotClient is already disconnected\n");
+    return;
+  }
+  close_socket(socket_fd);
+  socket_fd = -1;
+}
+
+void RobotClient::sendRequest(const ActuatorRequests &actuator_request) {
+  if (socket_fd == -1)
+    throw std::logic_error("RobotClient is not connected");
+  const uint32_t size = htonl(actuator_request.ByteSizeLong());
+#ifndef _WIN32
+  // This doesn't work on Windows, we should implement SocketOutputStream to make it work efficiently on Windows
+  // See https://stackoverflow.com/questions/23280457/c-google-protocol-buffers-open-http-socket
+  if (send(socket_fd, (char *)(&size), sizeof(uint32_t), 0) == -1) {
+    std::string error_msg = "Failed to send message of size: " + std::to_string(size) + " errno: " + std::to_string(errno);
+    disconnectClient();
+    throw std::runtime_error(error_msg);
+  }
+  google::protobuf::io::ZeroCopyOutputStream *zeroCopyStream = new google::protobuf::io::FileOutputStream(socket_fd);
+  actuator_request.SerializeToZeroCopyStream(zeroCopyStream);
+  delete zeroCopyStream;
+#else  // here we make a useless malloc, copy and free
+  char *output = (char *)malloc(sizeof(int) + size);
+  uint32_t *content_size = (uint32_t *)output;
+  *content_size = size;
+  uint32_t total_size = sizeof(uint32_t) + *content_size;
+  actuator_request.SerializeToArray(&output[sizeof(uint32_t)], content_size);
+  if (send(socket_fd, output, total_size, 0) == -1) {
+    std::string error_msg =
+      "Failed to send message of size: " + std::to_string(total_size) + " errno: " + std::to_string(errno);
+    free(output);
+    disconnectClient();
+    throw std::runtime_error(error_msg);
+  }
+  free(output);
+#endif
+}
+
+SensorMeasurements RobotClient::receive() {
+  uint32_t content_size_network;
+  receiveData((char *)&content_size_network, sizeof(uint32_t));
+  const int answer_size = ntohl(content_size_network);
+  if (answer_size > max_answer_size || answer_size == 0) {
+    disconnectClient();
+    throw std::logic_error("Unexpected size for the answer: " + std::to_string(answer_size) + " (probably out of sync)");
+  }
+  SensorMeasurements sensor_measurements;
+  char *buffer = (char *)malloc(answer_size);
+  receiveData(buffer, answer_size);
+  sensor_measurements.ParseFromArray(buffer, answer_size);
+  free(buffer);
+  // History is only updated when printing it
+  if (verbosity >= 3)
+    updateHistory(sensor_measurements);
+  if (verbosity >= 4) {
+    std::string printout;
+    google::protobuf::TextFormat::PrintToString(sensor_measurements, &printout);
+    std::cout << printout << std::endl;
+  }
+  return sensor_measurements;
+}
+
+bool RobotClient::isOk() {
+  return socket_fd != -1;
+}
+
+ActuatorRequests RobotClient::buildRequestMessage(const std::string &path) {
+  const char *message = read_file("actuator_requests.txt");
+  ActuatorRequests actuator_request;
+  google::protobuf::TextFormat::ParseFromString(message, &actuator_request);
+  return actuator_request;
+}
+
+void RobotClient::receiveData(char *buffer, int bytes) {
+  if (socket_fd == -1)
+    throw std::logic_error("RobotClient is not connected");
+  int received = 0;
+  while (received < bytes) {
+    int n = recv(socket_fd, buffer + received, bytes - received, 0);
+    if (n == -1) {
+      disconnectClient();
+      throw std::runtime_error("Failed to send message of size: " + std::to_string(bytes) + " errno: " + std::to_string(errno));
+    }
+    received += n;
+  }
+}
+
+void RobotClient::updateHistory(const SensorMeasurements &sensors) {
+  uint32_t msg_size = sensors.ByteSizeLong();
+  MessageProperty new_msg;
+  new_msg.simulated_time = sensors.time();
+  new_msg.real_time = sensors.real_time();
+  new_msg.msg_size = msg_size;
+  history_total_size += msg_size;
+  if (client_start == 0) {
+    client_start = new_msg.real_time;
+    last_history_print = new_msg.real_time;
+  }
+  // Adding new message + removing old ones
+  msg_history.push_front(new_msg);
+  while (msg_history.front().real_time - msg_history.back().real_time > history_period * 1000) {
+    history_total_size -= msg_history.back().msg_size;
+    msg_history.pop_back();
+  }
+  // Printing at fixed frequency
+  if (new_msg.real_time - last_history_print > history_period * 1000) {
+    if (msg_history.size() == 1) {
+      printf("Cannot compute stats on 1 message\n");
+    } else {
+      const MessageProperty &old_msg = msg_history.back();
+      double real_time_elapsed = new_msg.real_time - old_msg.real_time;
+      double simulated_time_elapsed = new_msg.simulated_time - old_msg.simulated_time;
+      double real_time_factor = simulated_time_elapsed / real_time_elapsed;
+      double bandwidth = history_total_size / (real_time_elapsed / 1000) / std::pow(2, 20);
+      printf("[%08.3f|%08.3f] real_time_factor: %f, bandwidth: %f MB/s\n", (new_msg.real_time - client_start) / 1000.0,
+             new_msg.simulated_time / 1000.0, real_time_factor, bandwidth);
+    }
+    last_history_print = new_msg.real_time;
+  }
+}

--- a/projects/samples/contests/robocup/controllers/player/robot_client.cpp
+++ b/projects/samples/contests/robocup/controllers/player/robot_client.cpp
@@ -2,6 +2,7 @@
 
 #ifdef _WIN32
 #include <winsock.h>
+#define sleep(x) Sleep(x)
 #else
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -152,7 +153,7 @@ void RobotClient::sendRequest(const ActuatorRequests &actuator_request) {
   uint32_t *content_size = (uint32_t *)output;
   *content_size = size;
   uint32_t total_size = sizeof(uint32_t) + *content_size;
-  actuator_request.SerializeToArray(&output[sizeof(uint32_t)], content_size);
+  actuator_request.SerializeToArray(&output[sizeof(uint32_t)], *content_size);
   if (send(socket_fd, output, total_size, 0) == -1) {
     std::string error_msg =
       "Failed to send message of size: " + std::to_string(total_size) + " errno: " + std::to_string(errno);

--- a/projects/samples/contests/robocup/controllers/player/robot_client.hpp
+++ b/projects/samples/contests/robocup/controllers/player/robot_client.hpp
@@ -1,0 +1,106 @@
+#include <deque>
+#include <memory>
+#include "messages.pb.h"
+
+class RobotClient {
+public:
+  RobotClient(const std::string &host, int port, int verbosity = 3);
+
+  /**
+   * Close socket if opened and free all resources associated to the current connection
+   * Returns true on success.
+   */
+  bool connectClient();
+
+  /**
+   * Close socket if opened and free all resources associated to the current connection
+   */
+  void disconnectClient();
+
+  /**
+   * Send the provided message to the simulator.
+   * On failure, the client is closed and a runtime_error is thrown afterwards.
+   */
+  void sendRequest(const ActuatorRequests &actuator_request);
+
+  /**
+   * Returns next sensor message received, or an empty pointer on failure. This call is blocking.
+   * On failure, the client is closed and a runtime_error is thrown afterwards.
+   */
+  SensorMeasurements receive();
+
+  /**
+   * Returns true if the client is connected and no error has been detected
+   */
+  bool isOk();
+
+  static ActuatorRequests buildRequestMessage(const std::string &path);
+
+private:
+  /**
+   * Host address
+   */
+  std::string host;
+
+  /**
+   * The destination port to establish connection
+   */
+  int port;
+
+  /**
+   * The file descriptor for the socket: -1 if connection is not established
+   */
+  int socket_fd;
+
+  /**
+   * 0: Silent mode, no error messages, even when the connection breaks
+   * 1: Only print error messages
+   * 2: Print messages on successful connection as well
+   * 3: Print statistics over messages received
+   * 4: Print all messages received
+   */
+  int verbosity;
+
+  struct MessageProperty {
+    uint32_t simulated_time;  // [ms]
+    uint64_t real_time;       // [ms]
+    uint32_t msg_size;        // number of bytes in the message
+  };
+  std::deque<MessageProperty> msg_history;
+
+  uint64_t history_total_size;
+  uint64_t client_start;
+  uint64_t last_history_print;
+
+  /**
+   * The period (in seconds) used to estimated bandwidth and real_time factor.
+   */
+  static float history_period;
+
+  /**
+   * The maximal size of messages that can be received, if the announced size of a message is larger than this, the connection
+   * will be considered as out of sync and the connection will automatically be closed.
+   */
+  static int max_answer_size;
+
+  /**
+   * The number of connection attempts before giving up
+   */
+  static int max_attempts;
+
+  /**
+   * The number of seconds to wait between two connection attempts
+   */
+  static int wait_time_sec;
+
+  /**
+   * Throws logic_error if the connection has not been started.
+   * In case an error occurs during reception, the connection is ended and a runtime_error is thrown
+   */
+  void receiveData(char *buffer, int bytes);
+
+  /**
+   * Update the message history with a message
+   */
+  void updateHistory(const SensorMeasurements &sensors);
+};


### PR DESCRIPTION
*This refactor hasn't been tested on Windows*

Client has been extracted to a dedicated file with a class for easier
usage by teams. A few features have been added:

- Client now attempts to connect several times before giving up
- Client keeps track of the messages received over the last 5 seconds and can
  print estimated real-time factor and bandwidth usage.
- Verbosity of the client can now be chosen at runtime.

Additionally, the default actuator requests also request the image.
