### PR TITLE
Improve overall performance

### DIFF
--- a/projects/samples/contests/robocup/worlds/robocup.wbt
+++ b/projects/samples/contests/robocup/worlds/robocup.wbt
@@ -6,7 +6,7 @@ WorldInfo {
   ]
   title "Robocup V-HL Kid"
   basicTimeStep 8
-  optimalThreadCount 8
+  optimalThreadCount 1
   physicsDisableTime 0.1
   physicsDisableLinearThreshold 0.1
   physicsDisableAngularThreshold 0.1


### PR DESCRIPTION
While trying to debug a rare crash of Webots occurring when one of the robot is deleted (after receiving a red card), I found out that setting the `WorldInfo.optimalThreadCount` to 1 was significantly improving the overall performance. I guess the multi-threading benefit is not good and the overhead of multi-threading is causing a loss of performance. By setting this value to 1 on my system I could observe a better performance. If you can test it on your system and also get a better performance, it would be nice to merge this PR as well.