### PR TITLE
[fix] add missing include

### DIFF
--- a/src/webots/maths/WbPrecision.hpp
+++ b/src/webots/maths/WbPrecision.hpp
@@ -16,6 +16,7 @@
 #define WB_PRECISION_HPP
 
 #include <math.h>
+#include <limits>
 #include <QtCore/QString>
 
 namespace WbPrecision {


### PR DESCRIPTION
Without this fix, I can't build the release branch.

```
In file included from maths/WbRotation.hpp:22,
                 from nodes/utils/WbHiddenKinematicParameters.hpp:18,
                 from nodes/WbSolid.hpp:18,
                 from nodes/WbSolidDevice.hpp:23,
                 from nodes/WbAccelerometer.hpp:18,
                 from nodes/WbAccelerometer.cpp:15:
maths/WbPrecision.hpp:30:59: error: ‘numeric_limits’ is not a member of ‘std’
   30 |   const double DOUBLE_EQUALITY_TOLERANCE = 10000.0 * std::numeric_limits<double>::epsilon();
      |                                                           ^~~~~~~~~~~~~~
maths/WbPrecision.hpp:30:74: error: expected primary-expression before ‘double’
   30 |   const double DOUBLE_EQUALITY_TOLERANCE = 10000.0 * std::numeric_limits<double>::epsilon();
      |                                                                          ^~~~~~
```

