### PR TITLE
Fixed clang format

### DIFF
--- a/src/webots/maths/WbPrecision.hpp
+++ b/src/webots/maths/WbPrecision.hpp
@@ -16,8 +16,8 @@
 #define WB_PRECISION_HPP
 
 #include <math.h>
-#include <limits>
 #include <QtCore/QString>
+#include <limits>
 
 namespace WbPrecision {
 


### PR DESCRIPTION
The fix proposed in #112 is breaking the cppcheck tests. This PR fixes it and will save us from upcoming conflicts when synchronizing with the Webots upstream.