### PR TITLE
Fix robot_player compilation in Ubuntu 18.04

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/robot_client.cpp
+++ b/projects/samples/contests/robocup/controllers/player/robot_client.cpp
@@ -16,7 +16,12 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>
 #include <cmath>
+#include <iostream>
 #include <stdexcept>
+
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+#define ByteSizeLong ByteSize
+#endif
 
 float RobotClient::history_period = 5;
 int RobotClient::max_answer_size = 1920 * 1080 * 3 + 1000;  // Adding some margin for other data than image


### PR DESCRIPTION
**Description**
`robot_player.cpp` currently doesn't compile under Ubuntu 18.04. This PR fixes the problem by adding a missing include and adding the `ByteSizeLong` patch also present in other files.