### PR TITLE
[fix] add missing include

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/robot_client.cpp
+++ b/projects/samples/contests/robocup/controllers/player/robot_client.cpp
@@ -17,6 +17,7 @@
 #include <google/protobuf/text_format.h>
 #include <cmath>
 #include <stdexcept>
+#include <iostream>
 
 float RobotClient::history_period = 5;
 int RobotClient::max_answer_size = 1920 * 1080 * 3 + 1000;  // Adding some margin for other data than image


### PR DESCRIPTION
```
In file included from /usr/include/arpa/inet.h:22:0,
                 from robot_client.cpp:7:
robot_client.cpp: In member function ‘void RobotClient::sendRequest(const ActuatorRequests&)’:
robot_client.cpp:149:48: error: ‘const class ActuatorRequests’ has no member named ‘ByteSizeLong’; did you mean ‘ByteSize’?
   const uint32_t size = htonl(actuator_request.ByteSizeLong());
                                                ^
robot_client.cpp: In member function ‘SensorMeasurements RobotClient::receive()’:
robot_client.cpp:201:10: error: ‘cout’ is not a member of ‘std’
     std::cout << printout << std::endl;
          ^~~~
robot_client.cpp:201:10: note: suggested alternative: ‘cbrt’
     std::cout << printout << std::endl;
          ^~~~
          cbrt
```
