### PR TITLE
Referee now check hands, feet and arms according to specification

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -503,11 +503,10 @@ def rotate_along_z(axis_and_angle):
 
 
 def append_solid(solid, solids):  # we list only the hands and feet
-    model_field = solid.getField('model')
-    if model_field:
-        model = model_field.getSFString()
-        suffix = model[-4:]
-        if suffix in ['hand', 'foot']:
+    name_field = solid.getField('name')
+    if name_field:
+        name = name_field.getSFString()
+        if name.endswith("[hand]") or name.endswith("[foot]"):
             solids.append(solid)
     children = solid.getProtoField('children') if solid.isProto() else solid.getField('children')
     for i in range(children.getCount()):
@@ -813,12 +812,14 @@ def update_team_contacts(team):
             node = robot.getContactPointNode(i)
             if not node:
                 continue
-            model_field = node.getField('model')
-            if model_field:
-                model = model_field.getSFString()
-                member = model.split(' ')[-1] if ' ' in model else model
-            else:
-                member = 'unknown body part'
+            name_field = node.getField('name')
+            member = 'unknown body part'
+            if name_field:
+                name = name_field.getSFString()
+                tag_start = name.rfind('[')
+                tag_end = name.rfind(']')
+                if tag_start != -1 and tag_end != -1:
+                    member = name[tag_start+1:tag_end]
             if point[2] > game.field.turf_depth:  # not a contact with the ground
                 if point in game.ball.contact_points:  # ball contact
                     if member in ['arm', 'hand']:

--- a/projects/samples/contests/robocup/protos/Darwin-opHinge2Robocup.proto
+++ b/projects/samples/contests/robocup/protos/Darwin-opHinge2Robocup.proto
@@ -947,7 +947,7 @@ PROTO Darwin-opHinge2Robocup [
                                       endPoint Solid {
                                         translation 0 -0.093 0
                                         rotation 1 0 0 -1.23
-                                        model "left foot"
+                                        name "footL[foot]"
                                         children [
                                           DEF DAnkleLShape Shape { # Motors
                                             appearance USE MOTOR_APPEARANCE
@@ -1362,7 +1362,7 @@ PROTO Darwin-opHinge2Robocup [
                                       endPoint Solid {
                                         translation 0 -0.093 0
                                         rotation -1 0 0 1.22
-                                        model "right foot"
+                                        name "footR[foot]"
                                         children [
                                           DEF DAnkleRShape Shape { # Motors
                                             appearance USE MOTOR_APPEARANCE
@@ -1555,7 +1555,6 @@ PROTO Darwin-opHinge2Robocup [
           endPoint Solid {
             translation 0 0.082 0
             rotation 0.6734 0.6734 0.3051 2.5494
-            model "left arm"
             children [
               DEF DShoulderLShape Shape {
                 appearance USE METAL_APPEARANCE
@@ -1603,7 +1602,7 @@ PROTO Darwin-opHinge2Robocup [
                   endPoint Solid {
                     translation 0 -0.016 0
                     rotation 0 0 -1 -0.4254
-                    model "left arm"
+                    name "armL[arm]"
                     children [
                       DEF DArmUpperLShape Group {
                         children [
@@ -1665,7 +1664,7 @@ PROTO Darwin-opHinge2Robocup [
                           endPoint Solid {
                             translation 0 -0.06 0.016
                             rotation 1 0 0 -2.0908
-                            model "left hand"
+                            name "handL[hand]"
                             children [
                               DEF LEFT_HAND_SLOT Group {
                                 children IS leftHandSlot
@@ -1753,7 +1752,7 @@ PROTO Darwin-opHinge2Robocup [
                   }
                 }
             ]
-            name "shoulderL"
+            name "shoulderL[arm]"
             boundingObject Transform {
               translation -0.009 -0.0065 0
               rotation 0 0 1 -0.785398
@@ -1807,7 +1806,6 @@ PROTO Darwin-opHinge2Robocup [
           endPoint Solid {
             translation 0 -0.082 0
             rotation 0.6826 0.6826 0.2611 2.6307
-            model "right arm"
             children [
               DEF DShoulderRShape Shape {
                 appearance USE METAL_APPEARANCE
@@ -1855,7 +1853,7 @@ PROTO Darwin-opHinge2Robocup [
                   endPoint Solid {
                     translation 0 -0.016 0
                     rotation 0 0 -1 0.4554
-                    model "right arm"
+                    name "armR[arm]"
                     children [
                       DEF DArmUpperRShape Group {
                         children [
@@ -1917,7 +1915,7 @@ PROTO Darwin-opHinge2Robocup [
                           endPoint Solid {
                             translation 0 -0.06 0.016
                             rotation -1 0 0 2.0808
-                            model "right hand"
+                            name "handR[hand]"
                             children [
                               DEF RIGHT_HAND_SLOT Group {
                                 children IS rightHandSlot
@@ -2005,7 +2003,7 @@ PROTO Darwin-opHinge2Robocup [
                   }
                 }
             ]
-            name "shoulderR"
+            name "shoulderR[arm]"
             boundingObject Transform {
               translation 0.009 -0.0065 0
               rotation 0 0 1 0.785398


### PR DESCRIPTION
*STATUS: All automated tests are passing*

This PR is expected to solve #122 

Compliance with the model specifications required the following changes:

- The field used is now `name` and not `model`
- Identification of the tag is based on brackets rather than the last word
- DarwinOpHinge2 has been updated

Note that the Darwin robot used for the tests is still not compliant to the model specifications (no hip, and shoulder tags).