### PR TITLE
Referee fix: avoid crash on SolidReference

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -518,7 +518,7 @@ def append_solid(solid, solids):  # we list only the hands and feet
         if child.getType() in [Node.HINGE_JOINT, Node.HINGE_2_JOINT, Node.SLIDER_JOINT, Node.BALL_JOINT]:
             endPoint = child.getProtoField('endPoint') if child.isProto() else child.getField('endPoint')
             solid = endPoint.getSFNode()
-            if solid.getType() == Node.NO_NODE:
+            if solid.getType() == Node.NO_NODE or solid.getType() == Node.SOLID_REFERENCE:
                 continue
             append_solid(solid, solids)
 


### PR DESCRIPTION
When using `SolidReference` in PROTO files, this resulted with the following error:

```
Traceback (most recent call last):
  File "referee.py", line 1946, in <module>
    list_solids()  # prepare lists of solids to monitor in each robot to compute the convex hulls
  File "referee.py", line 539, in list_solids
    list_team_solids(blue_team)
  File "referee.py", line 532, in list_team_solids
    append_solid(robot, solids)
  File "referee.py", line 523, in append_solid
    append_solid(solid, solids)
  File "referee.py", line 523, in append_solid
    append_solid(solid, solids)
  File "referee.py", line 523, in append_solid
    append_solid(solid, solids)
  [Previous line repeated 3 more times]
  File "referee.py", line 512, in append_solid
    for i in range(children.getCount()):
AttributeError: 'NoneType' object has no attribute 'getCount'
```

To my understanding since `SolidReference` is used as a reference to a solid, this node should be ignored by the `append_solid` function.

With this fix, the robot [GankenKun from CIT Brains](https://github.com/citbrains/GankenKun_webots/blob/main/protos/GankenKun.proto) is now being analysed without crash from the referee.