### PR TITLE
Fixing initial behavior and kickoff change for penalty shootouts

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/test_scenario.json
@@ -1,8 +1,22 @@
 [
     {
         "timing" : {
-            "time" : 12.0,
-            "clock_type" : "Simulated",
+            "time" : [0,4.5],
+            "clock_type" : "System",
+            "state" : "INITIAL"
+        },
+        "tests" : [
+            {
+                "name" : "Sanity check: in fast mode, expecting 5 seconds of INITIAL time",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 5.3,
+            "clock_type" : "System",
             "state" : "INITIAL"
         },
         "tests" : [


### PR DESCRIPTION
- Waiting same time as for regular games #133
- Fixing penalty_shootout test to better fit what is expected.
- Enabling the kickoff comment that was solved in the GC:
  - See https://github.com/RoboCup-Humanoid-TC/GameController/issues/136
- Adding a second test to check behaviors when kickoff is blue
  - Doing the requested modification to ensure it's working.

All tests passed.