### PR TITLE
Referee: backwards compatibility with Ubuntu 18.04

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/gamestate.py
+++ b/projects/samples/contests/robocup/controllers/referee/gamestate.py
@@ -14,7 +14,12 @@
 
 # Adapted from from https://github.com/RoboCup-Humanoid-TC/GameController/blob/master/protocols/python/gamestate.py
 
-from construct import Array, Byte, Bytes, Const, Enum, Flag, Int16sl, Int16ul, PaddedString, Struct
+from construct import Array, Byte, Bytes, Const, Enum, Flag, Int16sl, Int16ul, Struct
+try:
+    from construct import PaddedString
+except ImportError:
+    # construct < 2.9.39
+    from construct import String as PaddedString
 
 Short = Int16ul
 

--- a/projects/samples/contests/robocup/controllers/referee/udp_bouncer.py
+++ b/projects/samples/contests/robocup/controllers/referee/udp_bouncer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 #
 # Copyright 1996-2021 Cyberbotics Ltd.
 #
@@ -15,10 +15,15 @@
 # limitations under the License.
 
 import socket
-import queue
 import threading
 import json
 import time
+
+try:
+    from queue import SimpleQueue
+except ImportError:
+    # python < 3.7
+    from queue import Queue as SimpleQueue
 
 
 def log(message):
@@ -51,7 +56,7 @@ SERVER_IP = "0.0.0.0"
 BUFFER = 1024
 
 # Setting up a Queue to handle incoming packages
-package_queue = queue.SimpleQueue()
+package_queue = SimpleQueue()
 
 # List of registered clients to send the information to
 clients = []


### PR DESCRIPTION
**Description**
This PR contains two small patches to provide backwards compatibility with Ubuntu 18.04 which we are currently using in our setup:
* in construct 2.9.39, `String` was renamed to `PaddedString` ([commit](https://github.com/construct/construct/commit/0cc26daa39ed054ab1208298f3166654c8e79e2f)). Ubuntu 18.04 ships construct 2.8.16.
* `queue.SimpleQueue` was added in python 3.7. Ubuntu 18.04 comes with python 3.6. The normal `Queue` object can be used when `SimpleQueue` is not available.