### PR TITLE
Fix: sending out correct rgb images

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/player.cpp
+++ b/projects/samples/contests/robocup/controllers/player/player.cpp
@@ -558,13 +558,13 @@ public:
         measurement->set_width(width);
         measurement->set_height(height);
         measurement->set_quality(-1);  // raw image (JPEG compression not yet supported)
-        const unsigned char *rgba_image = camera->getImage();
+        const unsigned char *bgra_image = camera->getImage();
         const int rgb_image_size = width * height * 3;
         unsigned char *rgb_image = new unsigned char[rgb_image_size];
         for (int i = 0; i < width * height; i++) {
-          rgb_image[3 * i] = rgba_image[4 * i];
-          rgb_image[3 * i + 1] = rgba_image[4 * i + 1];
-          rgb_image[3 * i + 2] = rgba_image[4 * i + 2];
+          rgb_image[3 * i] = bgra_image[4 * i + 2];
+          rgb_image[3 * i + 1] = bgra_image[4 * i + 1];
+          rgb_image[3 * i + 2] = bgra_image[4 * i];
         }
         measurement->set_image(rgb_image, rgb_image_size);
         delete[] rgb_image;
@@ -573,7 +573,7 @@ public:
         // testing JPEG compression (impacts the performance)
         unsigned char *buffer = NULL;
         long unsigned int bufferSize = 0;
-        encode_jpeg(rgba_image, width, height, 95, &bufferSize, &buffer);
+        encode_jpeg(bgra_image, width, height, 95, &bufferSize, &buffer);
         free_jpeg(buffer);
         buffer = NULL;
 #endif


### PR DESCRIPTION
the player.cpp controller sends out BGR instead of RGB Data.
The getCamera() function in webots returns a 32bit BGRA value. (see
https://cyberbotics.com/doc/reference/camera?tab-language=c )
This implementation swaps B and R to create proper RGB raw format.
