### PR TITLE
Start the udp bouncer in a subprocess instead of threads

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1882,7 +1882,9 @@ try:
             if hasattr(game, 'use_bouncing_server') and game.use_bouncing_server:
                 command_line.append('-b')
                 command_line.append(game.host)
-                start_bouncing_server(game_config_file)
+                udp_bouncer_process = subprocess.Popen(["python3", "udp_bouncer.py", game_config_file])
+            else:
+                udp_bouncer_process = None
             game.controller_process = subprocess.Popen(command_line, cwd=os.path.join(GAME_CONTROLLER_HOME, 'build', 'jar'))
     except KeyError:
         GAME_CONTROLLER_HOME = None
@@ -2496,6 +2498,8 @@ if game.controller:
     game.controller.close()
 if game.controller_process:
     game.controller_process.terminate()
+if udp_bouncer_process:
+    udp_bouncer_process.terminate()
 
 if hasattr(game, 'record_simulation'):
     if game.record_simulation.endswith(".html"):

--- a/projects/samples/contests/robocup/controllers/referee/udp_bouncer.py
+++ b/projects/samples/contests/robocup/controllers/referee/udp_bouncer.py
@@ -18,6 +18,7 @@ import socket
 import queue
 import threading
 import json
+import sys
 import time
 
 
@@ -144,3 +145,7 @@ def start_bouncing_server(game_config):
     log("Server thread for Robot port started")
 
     log("Setup completed")
+
+
+if __name__ == "__main__":
+    start_bouncing_server(sys.argv[1])


### PR DESCRIPTION
**Description**
This pull request changes the udp bouncer to be started as a subprocess instead of in the same thread.

**Related Issues**
This pull request fixes issue #144.