### PR TITLE
[patch] Refactor referee test launchers

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_test.sh
@@ -1,54 +1,77 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+set -Eeuo pipefail
+
+# Exemplary usage: ./launch_test.sh ./ball_holding/multi_robot_kid
 
 if [ $# -lt 1 ]
 then
-    echo "Usage $0 <test_path> [--render]"
-    exit -1
+    >&2 echo "Usage $0 <test_path> [--render]"
+    exit 1
 fi
 
-WEBOTS_OPTIONS="--stdout --stderr --mode=fast"
+if ! [ -d "$1" ]; then
+    >&2 echo "Error: Expecting a folder for <test_path>"
+    exit 1
+fi
+
+WEBOTS_OPTIONS=(--stdout --stderr --mode=fast)
 
 if [ $# == 2 ]
 then
-    if [ $2 != "--render" ]
+    if [ "$2" != "--render" ]
     then
-        echo "Unknown option $2"
-        exit -1
+        >&2 echo "Unknown option $2"
+        exit 1
     fi
 else
-    WEBOTS_OPTIONS="${WEBOTS_OPTIONS} --no-rendering --minimize"
+    WEBOTS_OPTIONS+=(--no-rendering --minimize)
 fi
 
+if [ -z "${WEBOTS_HOME+x}" ]; then
+  >&2 echo "Error: WEBOTS_HOME is not set"
+  exit 1
+fi
 
-export PYTHONPATH="${WEBOTS_HOME}/projects/samples/contests/robocup/controllers/referee"  # this should be removed once https://github.com/cyberbotics/webots/issues/3011 is fixed
-if [ "$(expr substr $(uname -s) 1 10)" == "MSYS_NT-10" ]; then
-  WEBOTS="webots"
+if [ -z "${JAVA_HOME+x}" ]; then
+  >&2 echo "Error: JAVA_HOME is not set"
+  exit 1
+fi
+
+if [ -z "${GAME_CONTROLLER_HOME+x}" ]; then
+  >&2 echo "Error: GAME_CONTROLLER_HOME is not set"
+  exit 1
+fi
+
+export PYTHONPATH="$WEBOTS_HOME/projects/samples/contests/robocup/controllers/referee"  # this should be removed once https://github.com/cyberbotics/webots/issues/3011 is fixed
+# shellcheck disable=SC2003 # I don't care about this
+if [ "$(expr substr "$(uname -s)" 1 10)" == "MSYS_NT-10" ]; then
+  WEBOTS=webots
 else
-  WEBOTS="${WEBOTS_HOME}/webots"
+  WEBOTS=$WEBOTS_HOME/webots
 fi
 
-ROBOCUP_PATH="${WEBOTS_HOME}/projects/samples/contests/robocup"
-WEBOTS_WORLD="${ROBOCUP_PATH}/worlds/robocup.wbt"
+ROBOCUP_PATH=$WEBOTS_HOME/projects/samples/contests/robocup
+WEBOTS_WORLD=$ROBOCUP_PATH/worlds/robocup.wbt
 
-TEST_FOLDER="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
-TEST_CLIENT="${ROBOCUP_PATH}/controllers/player/test_client"
+TEST_FOLDER=$(cd "$1" && pwd)
+TEST_CLIENT=$ROBOCUP_PATH/controllers/player/test_client
 
-
-# Automatically launch test clients if applicable
-if [[ -f "${TEST_FOLDER}/clients.txt" ]]
+# Automatically launch test clients, if applicable
+if [[ -f "$TEST_FOLDER/clients.txt" ]]
 then
     if pgrep test_client; then
-        echo >&2 "Error: there are still clients running!"
+        >&2 echo "Error: There are still clients running!"
         exit 1
     fi
     client_id=1
-    while read line; do
-        ${TEST_CLIENT} $line > ${TEST_FOLDER}/client_${client_id}.log 2>&1 &
-        let client_id++
-    done < "${TEST_FOLDER}/clients.txt"
+    while read -r line; do
+        "$TEST_CLIENT" "$line" > "$TEST_FOLDER/client_$client_id.log" 2>&1 &
+        ((client_id++))
+    done < "$TEST_FOLDER/clients.txt"
 fi
 
-WEBOTS_ROBOCUP_TEST_SCENARIO="${TEST_FOLDER}/test_scenario.json" \
-                            WEBOTS_ROBOCUP_GAME="${TEST_FOLDER}/game.json" \
-                            $WEBOTS $WEBOTS_OPTIONS $WEBOTS_WORLD
+# Launch Webots
+WEBOTS_ROBOCUP_TEST_SCENARIO=$TEST_FOLDER/test_scenario.json \
+WEBOTS_ROBOCUP_GAME=$TEST_FOLDER/game.json \
+"$WEBOTS" "${WEBOTS_OPTIONS[@]}" "$WEBOTS_WORLD"


### PR DESCRIPTION
Summary:

* Quote vars to avoid splitting

* Remove unnecessary usage of "${VAR}" when just "$VAR" could have been
  used

* Remove unnecessary usage of quoting in var assignment, ie VAR="FOO",
  vs just VAR=FOO.

* Use more sane Bash options (`+set -Eeuo pipefail`)

`launch_all_tests` specific:

* `cd` to script dir because all paths are relative

* Use Bash arrays for TEST_FILES. You beforehand just assumed that the
  paths contain no whitespace.

* Show progress during executing

* Use color to display pass/ fail better

* Print the time each test took

* Add --lazy

* Add a timeout, so that tests never run indefinitely

`launch_test` specific:

* Checked if Webots env vars are set at all

* TEST_FOLDER was set weirdly - simplified this

