### PR TITLE
[patch] show progress of test launcher

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -16,14 +16,20 @@ readarray -d '' TEST_FILES < <(find . -name "test_scenario.json" -print0 | sort 
 
 TOT_SUCCESS=0
 TOT_TESTS=0
+NTH_TEST=0
 
 for test_file in "${TEST_FILES[@]}"
 do
+    ((NTH_TEST+=1))
+
     folder=$(dirname ${test_file})
     test_log="${folder}/test.log"
     referee_log="${folder}/referee.log"
+    msg_prefix="[$NTH_TEST/${#TEST_FILES[@]}] $folder"
+
     if [ $RUN_TESTS = true ]
     then
+        echo "$msg_prefix ..."
         ./launch_test.sh ${folder} &> ${test_log}
         cp ../log.txt ${referee_log}
     fi
@@ -35,7 +41,7 @@ do
     then
         RESULT="FAIL"
     fi
-    printf "%s %2d/%2d %s\n" $RESULT $NB_SUCCESS $NB_TESTS $folder
+    printf "$msg_prefix %s %2d/%2d\n" $RESULT $NB_SUCCESS $NB_TESTS
 
     ((TOT_SUCCESS+=NB_SUCCESS))
     ((TOT_TESTS+=NB_TESTS))


### PR DESCRIPTION
Show the number of the test that is currently running to get a sense of
progress.

Furthermore, print the name of the test before executing the test, so
that you are able to see which test is currently running (this is
especially interesting if a test runs indefinitely).
