### PR TITLE
Penalty shootouts: reducing sensitivity of goal line check

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/team_1.json
@@ -16,8 +16,8 @@
         "rotation": [0, 0, 1, 0]
       },
       "goalKeeperStartingPose": {
-        "translation": [-4.47, 0.2, 0.24],
-        "rotation": [0, 0, 1, 0]
+        "translation": [-4.51, 0.2, 0.27],
+        "rotation": [0, 1, 0, -0.05]
       }
     }
   }

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/team_2.json
@@ -16,7 +16,7 @@
         "rotation": [0, 0, 1, 0]
       },
       "goalKeeperStartingPose": {
-        "translation": [-4.47, 0, 0.24],
+        "translation": [-4.46, 0, 0.24],
         "rotation": [0, 0, 1, 0]
       }
     }

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts/test_scenario.json
@@ -42,7 +42,7 @@
             {
                 "name" : "T1. BLUE goalkeeper is properly positioned",
                 "target" : "BLUE_PLAYER_1",
-                "position" : [-4.47,0,0.24]
+                "position" : [-4.46,0,0.24]
             },
             {
                 "name" : "T1. Sanity check: mode is penalty shootout",
@@ -169,7 +169,7 @@
             {
                 "name" : "T2:RED goalkeeper is properly positioned",
                 "target" : "RED_PLAYER_1",
-                "position" : [-4.47,0.2,0.24]
+                "position" : [-4.51,0.2,0.24]
             }
         ]
     },
@@ -318,7 +318,7 @@
             {
                 "name" : "T3. BLUE goalkeeper is properly positioned",
                 "target" : "BLUE_PLAYER_1",
-                "position" : [-4.47,0,0.24]
+                "position" : [-4.46,0,0.24]
             }
         ]
     },

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts2/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts2/game.json
@@ -8,7 +8,7 @@
   "supervisor": "test_supervisor",
   "red": {
     "id": 1,
-    "config": "tests/game_phases/penalty_shootouts/team_1.json",
+    "config": "tests/game_phases/penalty_shootouts2/team_1.json",
     "hosts": [
       "127.0.0.1",
       "192.168.123.21",
@@ -25,7 +25,7 @@
   },
   "blue": {
     "id": 4,
-    "config": "tests/game_phases/penalty_shootouts/team_2.json",
+    "config": "tests/game_phases/penalty_shootouts2/team_2.json",
     "hosts": [
       "127.0.0.1",
       "192.168.123.41",


### PR DESCRIPTION
Reducing risks of false positive by requesting one continuous second of rule
infringement to penalize the robot. This should fix #162 

The initial problem is highlighted by doing slight modifications of the test.

- In `penalty_shootouts`: roughly 5 cm of difference allowed along x-axis
  - Goalkeeper red: slightly behind (x=-4.51) and slightly tilted backward
    - Robot is incorrectly considered as penalized
  - Goalkeeper blue: slightly in front of initial position

Additionally, links toward team files in `penalty_shootouts2` are fixed.