### PR TITLE
Fixing implementation of state synchronization with the GC

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/game.json
@@ -6,7 +6,6 @@
   "minimum_real_time_factor": 0,
   "side_left": "blue",
   "press_a_key_to_terminate": true,
-  "game_controller_synchronization": true,
   "use_bouncing_server": true,
   "red": {
     "id": 8,


### PR DESCRIPTION
Fixes #132

Now synchronization occurs in `game_controller_send` rather than the main loop
ensuring that sending two different state messages in the same step of the
Autoref does not break synchronization.

This includes a few additional modification
- Game variables are now declared before starting GC (required for some of them
  due to the implementation change)
- Fix the `wait_for_state` value in penalty_shootout after a goal
- Removing the `game_controller_synchronization` flag (was used everywhere and
  disabling it is inherently unsafe)

All tests are passing.