### PR TITLE
Fix test scripts on Windows

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -44,11 +44,11 @@ do
     folder=$(dirname ${test_file})
     test_log="${folder}/test.log"
     referee_log="${folder}/referee.log"
-    msg_prefix="[$NTH_TEST/${#TEST_FILES[@]}] $folder"
+    msg_prefix="[$NTH_TEST/${#TEST_FILES[@]}] ${folder:2}"
 
     if should_run_tests
     then
-        echo "$msg_prefix ..."
+        printf "$msg_prefix ..."
         ./launch_test.sh ${folder} &> ${test_log}
         cp ../log.txt ${referee_log}
     fi
@@ -57,9 +57,9 @@ do
     NB_TESTS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $2 }')
     if [ $NB_SUCCESS -lt $NB_TESTS ]
     then
-        printf "$COLOR_RED$msg_prefix %s %2d/%2d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
+        printf "\b\b\b$COLOR_RED %s %d/%d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
     else
-        printf "$COLOR_GREEN$msg_prefix %s %2d/%2d$COLOR_RESET\n" PASS $NB_SUCCESS $NB_TESTS
+        printf "\b\b\b$COLOR_GREEN %s %d/%d$COLOR_RESET\n" PASS $NB_SUCCESS $NB_TESTS
     fi
 
     ((TOT_SUCCESS+=NB_SUCCESS))

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -49,7 +49,7 @@ do
     if should_run_tests
     then
         printf '%-60.60srunning...' "$msg_prefix"
-        ./launch_test.sh ${folder} &> ${test_log}
+        ./launch_test.sh ${folder} | tee ${test_log} > /dev/null
         cp ../log.txt ${referee_log}
     fi
     RESULT_LINE=$(awk '/TEST RESULTS/ { print $3 }' ${test_log})

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -48,7 +48,7 @@ do
 
     if should_run_tests
     then
-        printf "$msg_prefix ..."
+        printf '%-60.60srunning...' "$msg_prefix"
         ./launch_test.sh ${folder} &> ${test_log}
         cp ../log.txt ${referee_log}
     fi
@@ -57,9 +57,9 @@ do
     NB_TESTS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $2 }')
     if [ $NB_SUCCESS -lt $NB_TESTS ]
     then
-        printf "\b\b\b$COLOR_RED %s %d/%d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
+        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_RED%s %d/%d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
     else
-        printf "\b\b\b$COLOR_GREEN %s %d/%d$COLOR_RESET\n" PASS $NB_SUCCESS $NB_TESTS
+        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_GREEN%s %d/%d$COLOR_RESET\n" PASS $NB_SUCCESS $NB_TESTS
     fi
 
     ((TOT_SUCCESS+=NB_SUCCESS))

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -60,9 +60,9 @@ do
     NB_TESTS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $2 }')
     if [ $NB_SUCCESS -lt $NB_TESTS ]
     then
-        printf "$COLOR_RED%s %d/%d$COLOR_RESET  \n" FAIL $NB_SUCCESS $NB_TESTS
+        printf "$COLOR_RED%s %d/%d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
     else
-        printf "$COLOR_GREEN%s %d/%d$COLOR_RESET  \n" PASS $NB_SUCCESS $NB_TESTS
+        printf "$COLOR_GREEN%s %d/%d$COLOR_RESET\n" PASS $NB_SUCCESS $NB_TESTS
     fi
 
     ((TOT_SUCCESS+=NB_SUCCESS))

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -48,7 +48,10 @@ do
 
     if should_run_tests
     then
-        printf '%-60.60srunning...' "$msg_prefix"
+        printf '%-60.60s' "$msg_prefix"
+        # On Windows the "| tee" is needed to ensure the output of the
+        # launch_test.sh is flushed and fully written in the output file.
+        # Using a standard redirection ">" is unfortunately not sufficient
         ./launch_test.sh ${folder} | tee ${test_log} > /dev/null
         cp ../log.txt ${referee_log}
     fi
@@ -57,9 +60,9 @@ do
     NB_TESTS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $2 }')
     if [ $NB_SUCCESS -lt $NB_TESTS ]
     then
-        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_RED%s %d/%d$COLOR_RESET  \n" FAIL $NB_SUCCESS $NB_TESTS
+        printf "$COLOR_RED%s %d/%d$COLOR_RESET  \n" FAIL $NB_SUCCESS $NB_TESTS
     else
-        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_GREEN%s %d/%d$COLOR_RESET  \n" PASS $NB_SUCCESS $NB_TESTS
+        printf "$COLOR_GREEN%s %d/%d$COLOR_RESET  \n" PASS $NB_SUCCESS $NB_TESTS
     fi
 
     ((TOT_SUCCESS+=NB_SUCCESS))

--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -57,9 +57,9 @@ do
     NB_TESTS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $2 }')
     if [ $NB_SUCCESS -lt $NB_TESTS ]
     then
-        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_RED%s %d/%d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
+        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_RED%s %d/%d$COLOR_RESET  \n" FAIL $NB_SUCCESS $NB_TESTS
     else
-        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_GREEN%s %d/%d$COLOR_RESET\n" PASS $NB_SUCCESS $NB_TESTS
+        printf "\b\b\b\b\b\b\b\b\b\b$COLOR_GREEN%s %d/%d$COLOR_RESET  \n" PASS $NB_SUCCESS $NB_TESTS
     fi
 
     ((TOT_SUCCESS+=NB_SUCCESS))

--- a/scripts/install/msys64_installer.sh
+++ b/scripts/install/msys64_installer.sh
@@ -35,6 +35,7 @@ declare -a DEVELOPMENT_PACKAGES=(
   "mingw-w64-x86_64-cppcheck" # coding style tests
   "mingw-w64-x86_64-gdb"      # debugging
   "diffutils"                 # cmp and diff utilities
+  "procps"                    # pgrep
 )
 
 if [ "$1" == "--dev" ]; then


### PR DESCRIPTION
This PR fixes the new test script so that it works on Windows / MSYS2 as well.
It also makes the output a little less redundant (each test now produces only one line).