### PR TITLE
[patch] ensure the log file contains a test result

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
+++ b/projects/samples/contests/robocup/controllers/referee/tests/launch_all_tests.sh
@@ -17,6 +17,27 @@ source "$script_dir/common.sh"
 
 assert_env_vars
 
+parse_log_file() {
+    local test_log=$1
+    local -n nb_success_=$2
+    local -n nb_tests_=$3
+
+    local result_line=$(awk '/TEST RESULTS/ { print $3 }' "$test_log")
+    nb_success_=$(echo "$result_line" | awk 'BEGIN { FS = "/" } ; { print $1 }')
+    nb_tests_=$(echo "$result_line" | awk 'BEGIN { FS = "/" } ; { print $2 }')
+}
+
+# When a test is launched but its execution is aborted (e.g. via ctrl+c), the
+# log file might not contain a test result.
+log_file_contains_test_result() {
+    local test_log=$1
+    local nb_success
+    local nb_tests
+    parse_log_file "$test_log" nb_success nb_tests
+
+    [[ -f "$test_log" && "$nb_success" && "$nb_tests" ]]
+}
+
 should_run_tests() {
     if [ "$PRINT_ONLY" = true ]; then
         # don't run the test
@@ -52,10 +73,16 @@ do
         ./launch_test.sh ${folder} &> ${test_log}
         cp ../log.txt ${referee_log}
     fi
-    RESULT_LINE=$(awk '/TEST RESULTS/ { print $3 }' ${test_log})
-    NB_SUCCESS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $1 }')
-    NB_TESTS=$(echo $RESULT_LINE | awk 'BEGIN { FS = "/" } ; { print $2 }')
-    if [ $NB_SUCCESS -lt $NB_TESTS ]
+
+    declare NB_SUCCESS
+    declare NB_TESTS
+    parse_log_file "$test_log" NB_SUCCESS NB_TESTS
+
+    if ! log_file_contains_test_result "$test_log"
+    then
+        printf "$COLOR_RED$msg_prefix %s %s$COLOR_RESET\n" FAIL "Log contains no test result. Maybe the test was aborted?"
+        continue
+    elif [ $NB_SUCCESS -lt $NB_TESTS ]
     then
         printf "$COLOR_RED$msg_prefix %s %2d/%2d$COLOR_RESET\n" FAIL $NB_SUCCESS $NB_TESTS
     else


### PR DESCRIPTION
After a test was launched, the log file could potentially contain no
test result. Then NB_SUCCESS and NB_TESTS are meaningless. Thus, test if
the log contains a test result at all.

This patch prepares --lazy because we need log_file_contains_test_result
and parse_log_file for implementing --lazy.

N.B.: `local -n` declares a "nameref"
