### PR TITLE
Placing ball correctly on game interruptions and moving robots away if required

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/field.py
+++ b/projects/samples/contests/robocup/controllers/referee/field.py
@@ -36,3 +36,8 @@ class Field:
         return (abs(point[0]) - radius > self.size_x - self.goal_area_length and
                 abs(point[0]) + radius < self.size_x and
                 abs(point[1]) + radius < self.goal_area_width / 2)
+
+    def circle_fully_inside_penalty_area(self, point, radius):
+        return (abs(point[0]) - radius > self.size_x - self.penalty_area_length and
+                abs(point[0]) + radius < self.size_x and
+                abs(point[1]) + radius < self.penalty_area_width / 2)

--- a/projects/samples/contests/robocup/controllers/referee/field.py
+++ b/projects/samples/contests/robocup/controllers/referee/field.py
@@ -14,6 +14,7 @@ class Field:
         self.opponent_distance_to_ball = 0.75 if size == 'kid' else 1.5
         self.ball_vincity = 0.75 if size == 'kid' else 1.5
         self.robot_radius = 0.3 if size == 'kid' else 0.5
+        self.place_ball_safety_dist = 0.5 if size == 'kid' else 1.0
         self.turf_depth = 0.01
         self.border_strip_width = 1
         self.line_width = 0.05

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1061,7 +1061,9 @@ def forceful_contact_foul(team, number, opponent_team, opponent_number, distance
     elif area[0] == 'i':  # inside penalty area
         interruption('PENALTYKICK')
     else:
-        interruption('FREEKICK')
+        offence_location = team['players'][number]['position']
+        freekick_team_id = game.blue.id if team['color'] == "red" else game.red.id
+        interruption('FREEKICK', freekick_team_id, offence_location)
 
 
 def goalkeeper_inside_own_goal_area(team, number):
@@ -1768,7 +1770,7 @@ def interruption(type, team=None, location=None):
     game.can_score_own = False
     game.ball_set_kick = True
     if location is not None:
-        game.ball_kick_translation[:2] = location
+        game.ball_kick_translation[:2] = location[:2]
     game.interruption = type
     game.phase = type
     game.ball_first_touch_time = 0
@@ -2521,10 +2523,10 @@ while supervisor.step(time_step) != -1 and not game.over:
     if game.state.game_state == 'STATE_PLAYING' and (game.interruption is None or game.interruption_seconds is not None):
         ball_holding = check_ball_holding()       # check for ball holding fouls
         if ball_holding:
-            interruption('FREEKICK', ball_holding, game.ball_position[:2])
+            interruption('FREEKICK', ball_holding, game.ball_position)
         ball_handling = check_ball_handling()
         if ball_handling:
-            interruption('FREEKICK', ball_handling)
+            interruption('FREEKICK', ball_handling, game.ball_position)
     check_penalized_in_field()                    # check for penalized robots inside the field
     if game.state.game_state != 'STATE_INITIAL':  # send penalties if needed
         send_penalties()

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1759,10 +1759,12 @@ def check_penalty_goal_line():
             player['invalidGoalkeeperStart'] = None
 
 
-def interruption(type, team=None, location=None):
+def interruption(type, team=None, location=None, is_goalkeeper_ball_manipulation=False):
     if type == 'FREEKICK':
         own_side = (game.side_left == team) ^ (game.ball_position[0] < 0)
-        if game.field.circle_fully_inside_goal_area(game.ball_position, game.ball_radius) and own_side:
+        inside_penalty_area = game.field.circle_fully_inside_penalty_area(game.ball_position, game.ball_radius)
+        if is_goalkeeper_ball_manipulation and inside_penalty_area and own_side:
+            # TODO: location should be adjusted to project ball on the penalty line parallel to the goal line
             type = 'INDIRECT_FREEKICK'
         else:
             type = 'DIRECT_FREEKICK'
@@ -2526,6 +2528,7 @@ while supervisor.step(time_step) != -1 and not game.over:
             interruption('FREEKICK', ball_holding, game.ball_position)
         ball_handling = check_ball_handling()
         if ball_handling:
+            # TODO: check if ball handling is performed by goalkeeper and if it is, then use it for interruption
             interruption('FREEKICK', ball_handling, game.ball_position)
     check_penalized_in_field()                    # check for penalized robots inside the field
     if game.state.game_state != 'STATE_INITIAL':  # send penalties if needed

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1761,8 +1761,8 @@ def check_penalty_goal_line():
 
 def interruption(type, team=None, location=None):
     if type == 'FREEKICK':
-        if (game.field.circle_fully_inside_goal_area(game.ball_position, game.ball_radius) and
-           (game.side_left == team and game.ball_position[0] > 0) or (game.side_left != team and game.ball_position[0] < 0)):
+        own_side = (game.side_left == team) ^ (game.ball_position[0] < 0)
+        if game.field.circle_fully_inside_goal_area(game.ball_position, game.ball_radius) and own_side:
             type = 'INDIRECT_FREEKICK'
         else:
             type = 'DIRECT_FREEKICK'

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1750,7 +1750,7 @@ def check_penalty_goal_line():
             player['invalidGoalkeeperStart'] = None
 
 
-def interruption(type, team=None):
+def interruption(type, team=None, location=None):
     if type == 'FREEKICK':
         if (game.field.circle_fully_inside_goal_area(game.ball_position, game.ball_radius) and
            (game.side_left == team and game.ball_position[0] > 0) or (game.side_left != team and game.ball_position[0] < 0)):
@@ -1760,6 +1760,8 @@ def interruption(type, team=None):
     game.in_play = None
     game.can_score_own = False
     game.ball_set_kick = True
+    if location is not None:
+        game.ball_kick_translation[:2] = location
     game.interruption = type
     game.phase = type
     game.ball_first_touch_time = 0
@@ -2396,7 +2398,7 @@ while supervisor.step(time_step) != -1 and not game.over:
     if game.state.game_state == 'STATE_PLAYING' and (game.interruption is None or game.interruption_seconds is not None):
         ball_holding = check_ball_holding()       # check for ball holding fouls
         if ball_holding:
-            interruption('FREEKICK', ball_holding)
+            interruption('FREEKICK', ball_holding, game.ball_position[:2])
         ball_handling = check_ball_handling()
         if ball_handling:
             interruption('FREEKICK', ball_handling)

--- a/projects/samples/contests/robocup/controllers/referee/tests/ball_holding/multi_robot_kid/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/ball_holding/multi_robot_kid/test_scenario.json
@@ -54,7 +54,8 @@
                 "name" : "Part A ends with direct freekick for BLUE",
                 "secondary_state" : "DIRECT_FREEKICK",
                 "secondary_team_id" : 8,
-                "secondary_phase" : 0
+                "secondary_phase" : 0,
+                "critical" : true
             },
             {
                 "name" : "Part A: robots are not penalized, RED1",
@@ -70,6 +71,21 @@
                 "name" : "Part A: robots are not penalized, BLUE1",
                 "target" : "BLUE_PLAYER_1",
                 "penalty" : 0
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [1,15],
+            "clock_type" : "Simulated",
+            "secondary_state" : "DIRECT_FREEKICK",
+            "phase" : 1
+        },
+        "tests" : [
+            {
+                "name" : "Part A: Ball is not moved away in SET phase",
+                "target" : "BALL",
+                "position" : [1.0,2.06,0.08]
             }
         ]
     },
@@ -102,6 +118,12 @@
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },
+        "tests" : [
+            {
+                "name" : "Part B. Freekick ended",
+                "secondary_state" : "NORMAL"
+            }
+        ],
         "actions" : [
             {
                 "target" : "BALL",

--- a/projects/samples/contests/robocup/controllers/referee/tests/ball_holding/multi_robot_kid/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/ball_holding/multi_robot_kid/test_scenario.json
@@ -83,9 +83,9 @@
         },
         "tests" : [
             {
-                "name" : "Part A: Ball is not moved away in SET phase",
+                "name" : "Part A: Ball is moved far from robots to advantage of BLUE team in SET phase",
                 "target" : "BALL",
-                "position" : [1.0,2.06,0.08]
+                "position" : [1.5,2.06,0.08]
             }
         ]
     },
@@ -99,22 +99,18 @@
         "actions" : [
             {
                 "target" : "RED_PLAYER_1",
-                "position" : [1.0, -0.8, 0.24]
+                "position" : [1.0, -0.3, 0.24]
             },
             {
                 "target" : "BLUE_PLAYER_1",
                 "position" : [1.0, 0.3, 0.24]
-            },
-            {
-                "target" : "RED_PLAYER_2",
-                "position" : [3.7, 2.0, 0.24]
             }
         ]
     },
     {
         "description" : "Setting up part B: placing ball after freekick ended",
         "timing" : {
-            "time" : 60.0,
+            "time" : 70.0,
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },
@@ -133,7 +129,7 @@
     },
     {
         "timing" : {
-            "time" : [63.0, 70.0],
+            "time" : [73.0, 80.0],
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },
@@ -162,7 +158,7 @@
     {
         "description" : "Setting up part C: placing objects",
         "timing" : {
-            "time" : 70.0,
+            "time" : 80.0,
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },
@@ -187,7 +183,7 @@
     },
     {
         "timing" : {
-            "time" : [73.0, 80.0],
+            "time" : [83.0, 90.0],
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },

--- a/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/charging/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/forceful_contact/charging/test_scenario.json
@@ -245,6 +245,26 @@
         ]
     },
     {
+        "description" : "After collision, move robots slightly apart to avoid risk of mixing with rules",
+        "timing" : {
+            "time" : 136,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [1.1, 0.75, 0.24],
+                "orientation" : [0, 0, 1, 1.57]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [0.75, 1.1, 0.24],
+                "orientation" : [0, 0, 1, 0]
+            }
+        ]
+    },
+    {
         "timing" : {
             "time" : [138.0, 140.0],
             "clock_type" : "Simulated",
@@ -253,7 +273,8 @@
         "tests" : [
             {
                 "name" : "D. Foul less than 1 meter from the ball -> direct freekick",
-                "secondary_state" : "DIRECT_FREEKICK"
+                "secondary_state" : "DIRECT_FREEKICK",
+                "secondary_team_id" : 9
             },
             {
                 "name" : "D. Player moving to the ball -> No penalty",
@@ -264,6 +285,23 @@
                 "name" : "D. Since freekick -> No penalty",
                 "target" : "BLUE_PLAYER_1",
                 "penalty" : 0
+            }
+        ]
+    },
+    {
+        "timing" :  {
+            "time" : 1,
+            "clock_type" : "Simulated",
+            "secondary_state" : "DIRECT_FREEKICK",
+            "phase" : 1
+        },
+        "tests" : [
+            {
+                "name" : "D. Ball is placed at the expected location",
+                "target" : "BALL",
+                "position" : [1.9, 1.0, 0.08],
+                "abs_tol" : 0.1,
+                "comment" : "BLUE 1 and RED 1 each covers two alternative pos"
             }
         ]
     }

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/corner/procedure/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/corner/procedure/test_scenario.json
@@ -147,12 +147,31 @@
     },
     {
         "timing" : {
+            "time" : 1,
+            "clock_type" : "Simulated",
+            "secondary_state" : "CORNERKICK",
+            "phase" : 1
+        },
+        "tests" : [
+            {
+                "name" : "Robot to close when placing ball is moved away 50cm",
+                "target" : "RED_PLAYER_1",
+                "position" : [-4.975,-3,0.24]
+            }
+        ]
+    },
+    {
+        "timing" : {
             "time" : 2,
             "clock_type" : "Simulated",
             "secondary_state" : "CORNERKICK",
             "phase" : 1
         },
         "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-4.8,-3,0.24]
+            },
             {
                 "target" : "BLUE_PLAYER_1",
                 "position" : [-4.5,-3.3,0.24]

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/goal_kick/procedure/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/goal_kick/procedure/test_scenario.json
@@ -202,6 +202,27 @@
                 "name" : "1st retake: ball properly respawned",
                 "target" : "BALL",
                 "position" : [0, -3, 0.08]
+            },
+            {
+                "name" : "1st retake: robot is moved 50cm away from the ball",
+                "target" : "RED_PLAYER_1",
+                "position" : [0,-3.475,0.24]
+            }
+        ]
+    },
+    {
+        "description" : "Moving robot to ball again because it has been moved away",
+        "timing" : {
+            "time" : 6,
+            "clock_type" : "Simulated",
+            "secondary_state" : "GOALKICK",
+            "phase" : 1,
+            "state_count" : 2
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [0,-3.2,0.24]
             }
         ]
     },
@@ -339,7 +360,8 @@
         "actions" : [
             {
                 "target" : "RED_PLAYER_1",
-                "position" : [0,-2.5,0.24]
+                "position" : [0,-2.5,0.24],
+                "orientation" : [0, 0, 1, 1.57]
             }
         ]
     },

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/README.md
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/README.md
@@ -1,0 +1,22 @@
+# Game Interruption - ball distance
+
+## What is tested
+
+- If a penalized robot is too close to the position ball went out, it is moved the other side
+- If a fallen robot is too close to the pos
+
+## Setup
+
+- Team RED has Kick-off and is on left side
+- One robot from each team are used
+
+## Description
+
+1. RED 1 touches the ball after PLAYING, the ball rolls over the touchline and crosses it.
+2. Throw-in for team BLUE is called.
+3. In phase 0, RED 1 falls near the ball
+4. In phase 1, ball is placed where the ball left and BLUE 1 is penalized on the opposite side.
+5. BLUE 1 kicks the ball in play, 10 seconds afterwards ball rolls out of the field near RED 1
+6. Throw-in for team RED is called
+7. In phase 1, RED 1 is moved away of its penalty position to place the ball
+8. RED 1 is moved to the other side, but penalty time is not reset

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/game.json
@@ -1,0 +1,43 @@
+{
+  "type": "NORMAL",
+  "class": "KID",
+  "host": "192.168.1.133",
+  "minimum_real_time_factor": 0,
+  "side_left": "red",
+  "kickoff": "red",
+  "supervisor": "test_supervisor",
+  "red": {
+    "id": 21,
+    "config": "tests/game_interruptions/throw_in/ball_distance/team_1.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.21",
+      "192.168.123.22",
+      "192.168.123.23",
+      "192.168.123.24"
+    ],
+    "ports": [
+      10001,
+      10002,
+      10003,
+      10004
+    ]
+  },
+  "blue": {
+    "id": 32,
+    "config": "tests/game_interruptions/throw_in/ball_distance/team_2.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.41",
+      "192.168.123.42",
+      "192.168.123.43",
+      "192.168.123.44"
+    ],
+    "ports": [
+      10021,
+      10022,
+      10023,
+      10024
+    ]
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/team_1.json
@@ -1,0 +1,24 @@
+{
+  "name": "Funny Dingos",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.0, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/team_2.json
@@ -1,0 +1,24 @@
+{
+  "name": "Agile Lynxes",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.0, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/throw_in/ball_distance/test_scenario.json
@@ -1,0 +1,303 @@
+[
+    {
+        "description" : "Placing robots inside their own field",
+        "timing" : {
+            "time" : 5.0,
+            "clock_type" : "Simulated",
+            "state" : "READY"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-2, -2, 0.24],
+                "orientation" : [0, 0, 1, 0]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [2, -2, 0.24],
+                "orientation" : [0, 0, 1, 3.14]
+            }
+        ]
+    },
+    {
+        "description" : "Sanity check, robots not penalized",
+        "timing" : {
+            "time" : 4.0,
+            "clock_type" : "Simulated",
+            "state" : "SET"
+        },
+        "tests" : [
+            {
+                "name" : "Sanity check: Red 1 is not penalized",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "Sanity check: Blue 1 is not penalized",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 2.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [1, 0, 0.24]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 3.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "force" : [50, 0, 0]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 8.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [-1, 3, 0.08]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 8.2,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "force" : [0, 10, 0]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 10.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "Throw-in is awarded to blue team",
+                "secondary_state" : "THROWIN",
+                "secondary_team_id" : 32,
+                "secondary_phase" : 0,
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [1,9],
+            "clock_type" : "Simulated",
+            "secondary_state" : "THROWIN",
+            "phase" : 0
+        },
+        "tests" : [
+            {
+                "name" : "Throw-in stays in phase 0 for 10 seconds",
+                "secondary_state" : "THROWIN",
+                "secondary_team_id" : 32,
+                "secondary_phase" : 0
+            }
+        ]
+    },
+    {
+        "description" : "RED 1 falls before phase 1",
+        "timing" : {
+            "time" : 7,
+            "clock_type" : "Simulated",
+            "secondary_state" : "THROWIN",
+            "phase" : 0
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-1, 2.8, 0.24],
+                "orientation" : [0, 1, 0, 1.57]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 4,
+            "clock_type" : "Simulated",
+            "secondary_state" : "THROWIN",
+            "phase" : 1
+        },
+        "tests" : [
+            {
+                "name" : "Ball placed on the touch line where ball left the field",
+                "target" : "BALL",
+                "position" : [-1, 3, 0.08]
+            },
+            {
+                "name" : "Red 1 is penalized to place the ball and moved to the opposite side",
+                "target" : "RED_PLAYER_1",
+                "position" : [-3.0, -3.11, 0.24],
+                "penalty" : 34
+            },
+            {
+                "name" : "Sanity check: Blue 1 is not penalized at beginning of phase 1",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
+            }
+        ],
+        "actions" : [
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [-1,3.15,0.24],
+                "orientation" : [0,0,1,1.57]
+            },
+            {
+                "target" : "BALL",
+                "force" : [0,30,0]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 6,
+            "clock_type" : "Simulated",
+            "secondary_state" : "THROWIN",
+            "phase" : 1
+        },
+        "tests" : [
+            {
+                "name" : "Throw-in is properly aborted",
+                "secondary_state" : "NORMAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 5,
+            "clock_type" : "Simulated",
+            "secondary_state" : "NORMAL",
+            "phase" : 0,
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "Kicking the ball too soon -> warning but no penalty",
+                "target" : "BLUE_PLAYER_1",
+                "warnings" : 1,
+                "penalty" : 0
+            }
+        ],
+        "actions" : [
+            {
+                "target" : "BALL",
+                "position" : [-3.3, -3.0, 0.08]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 10,
+            "clock_type" : "Simulated",
+            "secondary_state" : "NORMAL",
+            "phase" : 0,
+            "state_count" : 2
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "force" : [0, -10, 0]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 12,
+            "clock_type" : "Simulated",
+            "secondary_state" : "NORMAL",
+            "phase" : 0,
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "Throw-in is awarded to red team",
+                "secondary_state" : "THROWIN",
+                "secondary_team_id" : 21,
+                "secondary_phase" : 0
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 2,
+            "clock_type" : "Simulated",
+            "secondary_state" : "THROWIN",
+            "phase" : 1,
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "Ball placed on the touch line where ball left the field",
+                "target" : "BALL",
+                "position" : [-3.3, -3, 0.08]
+            },
+            {
+                "name" : "Red 1 is moved to place the ball and is still penalized",
+                "target" : "RED_PLAYER_1",
+                "position" : [-3.0, 3.11, 0.24],
+                "penalty" : 34
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [1,15],
+            "clock_type" : "Simulated",
+            "secondary_state" : "NORMAL",
+            "phase" : 0,
+            "state_count" : 3
+        },
+        "tests" : [
+            {
+                "name" : "Red 1 is still penalized 'interrupted' game does not count",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 34
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 22,
+            "clock_type" : "Simulated",
+            "secondary_state" : "NORMAL",
+            "phase" : 0,
+            "state_count" : 3
+        },
+        "tests" : [
+            {
+                "name" : "Red 1 penalty was not extended",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            }
+        ]
+    }
+]

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/kick_off/scenario_3/README.md
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/kick_off/scenario_3/README.md
@@ -12,7 +12,7 @@ circle, then the goal is valid
 
 ## Description
 
-1. BLUE 2 touches the ball after PLAYING, ball moves outside the center circle
-2. BLUE 2 moves out of center circle
-3. BLUE 2 kicks the ball in the goal
+1. BLUE 1 touches the ball after PLAYING, ball moves outside the center circle
+2. BLUE 1 moves out of center circle
+3. BLUE 1 kicks the ball in the goal
 4. A goal is scored

--- a/projects/samples/contests/robocup/controllers/test_supervisor/rc_testing.py
+++ b/projects/samples/contests/robocup/controllers/test_supervisor/rc_testing.py
@@ -306,6 +306,7 @@ class Test:
         self._score = score
         self._kick_off_team = kick_off_team
         self._critical = critical
+        self._abs_tol = POS_ABS_TOL
         self._msg = []
         self._success = True
 
@@ -374,7 +375,11 @@ class Test:
         t._score = dic.get("score")
         t._kick_off_team = dic.get("kick_off_team")
         t._critical = dic.get("critical", False)
+        t._abs_tol = dic.get("abs_tol", POS_ABS_TOL)
         return t
+
+    def _getAbsTol(self):
+        return self._abs_tol
 
     def _getTargetGCData(self, status):
         splitted_target = self._target.split("_")
@@ -393,7 +398,7 @@ class Test:
             raise RuntimeError("{self._name} tests position and has no target")
         target = supervisor.getFromDef(self._target)
         received_pos = target.getField('translation').getSFVec3f()
-        if not np.allclose(self._position, received_pos, atol=POS_ABS_TOL):
+        if not np.allclose(self._position, received_pos, atol=self._getAbsTol()):
             failure_msg = f"Position Invalid at {status.getFormattedTime()}: "\
                 f"expecting {self._position}, received {received_pos}"
             print(f"Failure in test {self._name}\n\t{failure_msg}")


### PR DESCRIPTION
This address #156 and the consequences of doing it, i.e. handling the cases where just placing the ball where the foul occurred has risks of placing the ball in intersection with a robot

Requested tasks:
- [X] Write repositioning system in [Rulebook](https://cdn.robocup.org/hl/wp/2021/05/V-HL21_Rules_v3.pdf), Line 825.
- [x] Place properly ball during
    - [X] ball_holding
    - [x] ball_handling
    - [x] Forceful contact
- [x] Test use cases
    - [x] Moving only penalized robots
    - [x] Removing fallen robots
    - [X] Placing ball at alternative locations, see `ball_holding/multi_robot_kid`, `forceful_contact/charging`
    - [X] Moving robots away because there is no alternative locations, see `goal_kick/procedure` and `corner/procedure`