### PR TITLE
Improve verbosity for forceful contact fouls

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/forceful_contact_matrix.py
+++ b/projects/samples/contests/robocup/controllers/referee/forceful_contact_matrix.py
@@ -27,6 +27,14 @@ class ForcefulContactMatrix:
         index = int(time_count / self.time_step) % self.time_window_size
         return self.matrix[int(red_number) - 1][int(blue_number) - 1][index]
 
+    def collision_time(self, red_number, blue_number):
+        """Return collision time in seconds of the collision between both robots"""
+        sum = 0
+        for touch in self.matrix[int(red_number) - 1][int(blue_number) - 1]:
+            if touch:
+                sum += 1
+        return sum * self.time_step / 1000
+
     def long_collision(self, red_number, blue_number):
         sum = 0
         for touch in self.matrix[int(red_number) - 1][int(blue_number) - 1]:

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1713,6 +1713,7 @@ def penalty_kicker_player():
         return player
     return None
 
+
 def get_penalty_shootout_msg():
     trial = game.penalty_shootout_count + 1
     name = "penalty shoot-out"
@@ -1720,6 +1721,7 @@ def get_penalty_shootout_msg():
         name = f"extended {name}"
         trial -= 10
     return f"{name} {trial}/10"
+
 
 def set_penalty_positions():
     info(f"Setting positions for {get_penalty_shootout_msg}")
@@ -1769,7 +1771,6 @@ def stop_penalty_shootout():
         return True
     diff = abs(game.state.teams[0].score - game.state.teams[1].score)
     if game.penalty_shootout_count == 10 and diff > 0:
-        info(message)
         return True
     kickoff_team = game.state.teams[0] if game.kickoff == game.state.teams[0].team_number else game.state.teams[1]
     kickoff_team_leads = kickoff_team.score >= game.state.teams[0].score and kickoff_team.score >= game.state.teams[1].score

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1098,7 +1098,9 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
         blue_number = number
     if game.forceful_contact_matrix.long_collision(red_number, blue_number):
         if d1 < FOUL_VINCITY_DISTANCE and d1 - d2 > FOUL_DISTANCE_THRESHOLD:
-            forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'long collision')
+            forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
+                                  f'long collision (more than {FOUL_PUSHING_TIME} second'
+                                  f' over a time window of {FOUL_PUSHING_PERIOD} seconds)')
             return True
     v1 = p1['velocity']
     v2 = p2['velocity']

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1099,8 +1099,8 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
     if game.forceful_contact_matrix.long_collision(red_number, blue_number):
         if d1 < FOUL_VINCITY_DISTANCE and d1 - d2 > FOUL_DISTANCE_THRESHOLD:
             forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                  f'long collision (more than {FOUL_PUSHING_TIME} second'
-                                  f' over a time window of {FOUL_PUSHING_PERIOD} seconds)')
+                                  f'long collision: more than {FOUL_PUSHING_TIME} second'
+                                  f' over a time window of {FOUL_PUSHING_PERIOD} seconds')
             return True
     v1 = p1['velocity']
     v2 = p2['velocity']
@@ -1112,14 +1112,17 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
         if moves_to_ball(p2, v2, v2_squared):
             if not moves_to_ball(p1, v1, v1_squared):
                 forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                      'opponent moving towards the ball, charge')
+                                      'opponent moving towards the ball, charge: '
+                                      f'{d1} < {FOUL_VINCITY_DISTANCE}')
                 return True
             if d1 - d2 > FOUL_DISTANCE_THRESHOLD:
                 forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                      'opponent moving towards the ball, charge from behind')
+                                      'opponent moving towards the ball, charge from behind: '
+                                      f'{d1} - {d2} > {FOUL_DISTANCE_THRESHOLD}')
                 return True
     elif math.sqrt(v1_squared) - math.sqrt(v2_squared) > FOUL_SPEED_THRESHOLD:
-        forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'violent collision')
+        forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'violent collision: '
+                              f'{math.sqrt(v1_squared)} - {math.sqrt(v2_squared)} > {FOUL_SPEED_THRESHOLD}')
         return True
     return False
 

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -87,18 +87,25 @@ GOAL_HALF_WIDTH = GOAL_WIDTH / 2
 global supervisor, game, red_team, blue_team, log_file, time_count, time_step, game_controller_udp_filter
 
 
-def log(message, type):
-    if type == 'Warning':
+def log(message, msg_type, force_flush=True):
+    if type(message) is list:
+        for m in message:
+            log(m, msg_type, False)
+        if log_file and force_flush:
+            log_file.flush()
+        return
+    if msg_type == 'Warning':
         console_message = f'{AnsiCodes.YELLOW_FOREGROUND}{AnsiCodes.BOLD}{message}{AnsiCodes.RESET}'
-    elif type == 'Error':
+    elif msg_type == 'Error':
         console_message = f'{AnsiCodes.RED_FOREGROUND}{AnsiCodes.BOLD}{message}{AnsiCodes.RESET}'
     else:
         console_message = message
-    print(console_message, file=sys.stderr if type == 'Error' else sys.stdout)
+    print(console_message, file=sys.stderr if msg_type == 'Error' else sys.stdout)
     if log_file:
         real_time = int(1000 * (time.time() - log.real_time)) / 1000
-        log_file.write(f'[{real_time:08.3f}|{time_count / 1000:08.3f}] {type}: {message}\n')  # log real and virtual times
-        log_file.flush()
+        log_file.write(f'[{real_time:08.3f}|{time_count / 1000:08.3f}] {msg_type}: {message}\n')  # log real and virtual times
+        if force_flush:
+            log_file.flush()
 
 
 log.real_time = time.time()
@@ -1039,11 +1046,6 @@ def send_penalty(player, penalty, reason, log=None):
 
 def forceful_contact_foul(team, number, opponent_team, opponent_number, distance_to_ball, message):
     player = team['players'][number]
-    if 'penalty_immunity' in player:
-        if player['penalty_immunity'] < time_count:
-            del player['penalty_immunity']
-        else:
-            return
     if player['outside_penalty_area']:
         area = 'outside penalty area'
     else:
@@ -1082,12 +1084,28 @@ def moves_to_ball(player, velocity, velocity_squared):
     return angle < FOUL_DIRECTION_THRESHOLD
 
 
+def readable_number_list(number_list, width=5, nb_digits=2):
+    fmt = f"%{width}.{nb_digits}f"
+    return f"[{' '.join([fmt % elem for elem in number_list])}]"
+
+
 def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
     p1 = team['players'][number]
+    if 'penalty_immunity' in p1:
+        if p1['penalty_immunity'] < time_count:
+            del p1['penalty_immunity']
+        else:
+            return
     p2 = opponent_team['players'][opponent_number]
     d1 = distance2(p1['position'], game.ball_position)
     d2 = distance2(p2['position'], game.ball_position)
+    p1_str = f"{team['color']} {number}"
+    p2_str = f"{opponent_team['color']} {opponent_number}"
+    debug_messages = [f"Check if {p1_str} is performing a foul on {p2_str}",
+                      f"{p1_str:6s}: at {readable_number_list(p1['position'])}, dist to ball: {d1:.2f}",
+                      f"{p2_str:6s}: at {readable_number_list(p2['position'])}, dist to ball: {d2:.2f}"]
     if goalkeeper_inside_own_goal_area(opponent_team, opponent_number):
+        info(debug_messages)
         forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'goalkeeper')
         return True
     if team == red_team:
@@ -1098,9 +1116,11 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
         blue_number = number
     if game.forceful_contact_matrix.long_collision(red_number, blue_number):
         if d1 < FOUL_VINCITY_DISTANCE and d1 - d2 > FOUL_DISTANCE_THRESHOLD:
-            forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                  f'long collision: more than {FOUL_PUSHING_TIME} second'
-                                  f' over a time window of {FOUL_PUSHING_PERIOD} seconds')
+            collision_time = game.forceful_contact_matrix.get_collision_time(red_number, blue_number)
+            debug_messages.append(f"Pushing time: {collision_time} > {FOUL_PUSHING_TIME} over the last {FOUL_PUSHING_PERIOD}")
+            debug_messages.append(f"Difference of distance: {d1-d2} > {FOUL_DISTANCE_THRESHOLD}")
+            info(debug_messages)
+            forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'long_collision')
             return True
     v1 = p1['velocity']
     v2 = p2['velocity']
@@ -1108,19 +1128,25 @@ def check_team_forceful_contacts(team, number, opponent_team, opponent_number):
     v2_squared = v2[0] * v2[0] + v2[1] * v2[1]
     if not v1_squared > FOUL_SPEED_THRESHOLD * FOUL_SPEED_THRESHOLD:
         return False
+    debug_messages.append(f"{p1_str:6s}: velocity: {readable_number_list(v1[:3])}, speed: {math.sqrt(v1_squared):.2f}")
+    debug_messages.append(f"{p2_str:6s}: velocity: {readable_number_list(v2[:3])}, speed: {math.sqrt(v2_squared):.2f}")
     if d1 < FOUL_VINCITY_DISTANCE:
+        debug_messages.append(f"{p1_str} is close to the ball ({d1:.2f} < {FOUL_VINCITY_DISTANCE})")
         if moves_to_ball(p2, v2, v2_squared):
             if not moves_to_ball(p1, v1, v1_squared):
+                info(debug_messages)
                 forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                      'opponent moving towards the ball, charge: '
-                                      f'{d1} < {FOUL_VINCITY_DISTANCE}')
+                                      'opponent moving towards the ball, charge')
                 return True
             if d1 - d2 > FOUL_DISTANCE_THRESHOLD:
+                debug_messages.append(f"{p2_str} is significantly closer to the ball than {p1_str}: "
+                                      f"({d1-d2:.2f} < {FOUL_DISTANCE_THRESHOLD})")
+                info(debug_messages)
                 forceful_contact_foul(team, number, opponent_team, opponent_number, d1,
-                                      'opponent moving towards the ball, charge from behind: '
-                                      f'{d1} - {d2} > {FOUL_DISTANCE_THRESHOLD}')
+                                      'opponent moving towards the ball, charge from behind')
                 return True
     elif math.sqrt(v1_squared) - math.sqrt(v2_squared) > FOUL_SPEED_THRESHOLD:
+        info(debug_messages)
         forceful_contact_foul(team, number, opponent_team, opponent_number, d1, 'violent collision: '
                               f'{math.sqrt(v1_squared)} - {math.sqrt(v2_squared)} > {FOUL_SPEED_THRESHOLD}')
         return True

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1834,22 +1834,22 @@ def check_penalty_goal_line():
             player['invalidGoalkeeperStart'] = None
 
 
-def interruption(type, team=None, location=None, is_goalkeeper_ball_manipulation=False):
-    if type == 'FREEKICK':
+def interruption(interruption_type, team=None, location=None, is_goalkeeper_ball_manipulation=False):
+    if interruption_type == 'FREEKICK':
         own_side = (game.side_left == team) ^ (game.ball_position[0] < 0)
         inside_penalty_area = game.field.circle_fully_inside_penalty_area(game.ball_position, game.ball_radius)
         if is_goalkeeper_ball_manipulation and inside_penalty_area and own_side:
             # TODO: location should be adjusted to project ball on the penalty line parallel to the goal line
-            type = 'INDIRECT_FREEKICK'
+            interruption_type = 'INDIRECT_FREEKICK'
         else:
-            type = 'DIRECT_FREEKICK'
+            interruption_type = 'DIRECT_FREEKICK'
     game.in_play = None
     game.can_score_own = False
     game.ball_set_kick = True
     if location is not None:
         game.ball_kick_translation[:2] = location[:2]
-    game.interruption = type
-    game.phase = type
+    game.interruption = interruption_type
+    game.phase = interruption_type
     game.ball_first_touch_time = 0
     game.interruption_countdown = SIMULATED_TIME_INTERRUPTION_PHASE_0
     if not team:
@@ -1860,7 +1860,7 @@ def interruption(type, team=None, location=None, is_goalkeeper_ball_manipulation
     reset_ball_touched()
     info(f'Ball not in play, will be kicked by a player from the {game.ball_must_kick_team} team.')
     color = 'red' if game.interruption_team == game.red.id else 'blue'
-    info(f'{GAME_INTERRUPTIONS[type].capitalize()} awarded to {color} team.')
+    info(f'{GAME_INTERRUPTIONS[interruption_type].capitalize()} awarded to {color} team.')
     game_controller_send(f'{game.interruption}:{game.interruption_team}')
 
 
@@ -2392,8 +2392,8 @@ try:
                         if game.over:
                             break
                     elif game.state.first_half:
-                        type = 'knockout ' if game.type == 'KNOCKOUT' and game.overtime else ''
-                        info(f'End of {type}first half.')
+                        game_type = 'knockout ' if game.type == 'KNOCKOUT' and game.overtime else ''
+                        info(f'End of {game_type} first half.')
                         flip_sides()
                         reset_teams('halfTimeStartingPose')
                         game.kickoff = game.blue.id if game.kickoff == game.red.id else game.red.id
@@ -2549,12 +2549,12 @@ try:
                 #       now automatic.
                 if game.ready_real_time is None:
                     if game.overtime:
-                        type = 'knockout '
+                        game_type = 'knockout '
                         game_controller_send('STATE:OVERTIME-SECOND-HALF')
                     else:
-                        type = ''
+                        game_type = ''
                         game_controller_send('STATE:SECOND-HALF')
-                    info(f'Beginning of {type}second half.')
+                    info(f'Beginning of {game_type}second half.')
                     game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
             elif game.type == 'KNOCKOUT' and game.overtime and game.state.teams[0].score == game.state.teams[1].score:
                 if game.ready_real_time is None:
@@ -2591,7 +2591,7 @@ try:
                 game_type = ''
                 if game.overtime:
                     game_type = 'overtime '
-                info(f'Beginning of {game_type} second half.')
+                info(f'Beginning of {game_type}second half.')
                 kickoff()
                 game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
 


### PR DESCRIPTION
Fixes #184.

In the original version, I tried to write human understandable messages allowing us to distinguish between the different cases of forceful contacts:

- `goalkeeper` is raised when the contact occurs against a goal keeper inside its own goal area.
- `long collision` is raised when the contact last for more than 1 second in a time window of 2 seconds (precision added in this PR).
- `opponent moving towards the ball, charge`: as it says opponent moving towards ball and current player no moving towards ball.
- `opponent moving towards the ball, charge from behind`: opponent moving towards ball and `d1 - d1 > FOUL_DISTANCE_THRESHOLD`
- `violent collision`: `velocity1 - velocity2 > FOUL_SPEED_THRESHOLD`

I added more details about these 5 cases (numerical values). However, I am afraid they will still be hard to understand...

I am not sure how to further improve this...
