### PR TITLE
Fix penalty kicks

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1124,7 +1124,7 @@ def forceful_contact_foul(team, number, opponent_team, opponent_number, distance
     freekick_team_id = game.blue.id if team['color'] == "red" else game.red.id
     if distance_to_ball > FOUL_BALL_DISTANCE or not game.in_play:
         send_penalty(player, 'PHYSICAL_CONTACT', 'forceful contact foul')
-    elif area[0] == 'i':  # inside penalty area
+    elif area[0] == 'i' and player['inside_own_side']:  # inside own penalty area
         interruption('PENALTYKICK', freekick_team_id)
     else:
         offence_location = team['players'][number]['position']

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1125,7 +1125,10 @@ def forceful_contact_foul(team, number, opponent_team, opponent_number, distance
     if distance_to_ball > FOUL_BALL_DISTANCE or not game.in_play:
         send_penalty(player, 'PHYSICAL_CONTACT', 'forceful contact foul')
     elif area[0] == 'i' and player['inside_own_side']:  # inside own penalty area
-        interruption('PENALTYKICK', freekick_team_id)
+        ball_reset_location = [game.field.penalty_mark_x, 0]
+        if team['players'][number]['position'][0] < 0:
+            ball_reset_location[0] *= -1
+        interruption('PENALTYKICK', freekick_team_id, ball_reset_location)
     else:
         offence_location = team['players'][number]['position']
         interruption('FREEKICK', freekick_team_id, offence_location)


### PR DESCRIPTION
Fixing bugs related to penalty kicks during games

- Now attributed only if the offense takes place in *the offenders* penalty area (previously was in any penalty area), fixes #207 
- Ball is now properly placed, fixes #208
- Adding a condition to prevent Autoref to ask for finish because apparently 'remaining_seconds' can be '-100' when the penalty kick is called.