### PR TITLE
Fix actuators disabling

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1825,8 +1825,8 @@ def next_penalty_shootout():
     flip_sides()
     info(f'fliped sides: game.side_left = {game.side_left}')
     if penalty_kicker_player():
-        set_penalty_positions()
         game_controller_send('STATE:SET')
+        set_penalty_positions()
     else:
         info("Skipping penalty trial because team has no kicker available")
         game_controller_send('STATE:SET')


### PR DESCRIPTION
This PR ensure that a similar procedure is taken for all the cases where the Autoref `reset` the position of players (i.e. changes both, pose and posture). Those cases are:

1. Removal penalty
2. Set position at the beginning of half time
3. Set position at the beginning of a penalty kick (kicker or goalkeeper)

Since 1 was properly working, 2 and 3 have a behavior similar to 1 now.

Finally, a minimal duration of disabling the actuators is used rather than relying on `secs_till_unpenalized` transition which is expected to fix #217 

Current status
- [x] Automated tests
- [x] Testing effects in games
- [x] Feedback from teams