### PR TITLE
Ball positioning at the beginning of second half with testing

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1937,6 +1937,14 @@ def goal_kick():
     interruption('GOALKICK')
 
 
+def move_ball_away():
+    """Places ball far away from field for phases where the referee is supposed to hold it in it's hand"""
+    target_location = [100, 100, game.ball_radius + 0.05]
+    game.ball.resetPhysics()
+    game.ball_translation.setSFVec3f(target_location)
+    info("Moved ball out of the field temporarily")
+
+
 def kickoff():
     color = 'red' if game.kickoff == game.red.id else 'blue'
     info(f'Kick-off is {color}.')
@@ -1952,6 +1960,7 @@ def kickoff():
     game.can_score = False        # or was touched by another player
     game.can_score_own = False
     game.kicking_player_number = None
+    move_ball_away()
     info(f'Ball not in play, will be kicked by a player from the {game.ball_must_kick_team} team.')
 
 
@@ -2616,17 +2625,7 @@ try:
                 if game.state.seconds_remaining <= 0:
                     next_penalty_shootout()
             elif game.state.first_half:
-                # NOTE: this part is probably dead code that is never used, transition from end of first Half to initial is
-                #       now automatic.
-                if game.ready_real_time is None:
-                    if game.overtime:
-                        game_type = 'knockout '
-                        game_controller_send('STATE:OVERTIME-SECOND-HALF')
-                    else:
-                        game_type = ''
-                        game_controller_send('STATE:SECOND-HALF')
-                    info(f'Beginning of {game_type}second half.')
-                    game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
+                game.ready_real_time = None
             elif game.type == 'KNOCKOUT' and game.overtime and game.state.teams[0].score == game.state.teams[1].score:
                 if game.ready_real_time is None:
                     info('Beginning of the knockout first half.')

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/second_half/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/second_half/test_scenario.json
@@ -14,6 +14,11 @@
                 "critical" : true
             },
             {
+                "name" : "1st Half: Ball is placed far from the field",
+                "target" : "BALL",
+                "position" : [100, 100, 0.08]
+            },
+            {
                 "name" : "Sanity check: RED has kick-off",
                 "kick_off_team" : 5
             }
@@ -46,6 +51,20 @@
                 "target" : "BLUE_PLAYER_2",
                 "position" : [2, 2, 0.24],
                 "orientation" : [0, 0, 1, 3.14]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 1.0,
+            "clock_type" : "Simulated",
+            "state" : "SET"
+        },
+        "tests" : [
+            {
+                "name" : "1st Half: Ball is placed at center of the field on SET",
+                "target" : "BALL",
+                "position" : [0, 0, 0.08]
             }
         ]
     },
@@ -135,7 +154,7 @@
     },
     {
         "timing" : {
-            "time" : [0,14.5],
+            "time" : [1,14.5],
             "clock_type" : "System",
             "state" : "INITIAL",
             "state_count" : 2
@@ -144,6 +163,11 @@
             {
                 "name" : "Staying in INITIAL for 15 real-time seconds",
                 "state" : "INITIAL"
+            },
+            {
+                "name" : "2nd Half: Ball is placed far from the field",
+                "target" : "BALL",
+                "position" : [100, 100, 0.08]
             }
         ]
     },
@@ -233,6 +257,22 @@
         ]
     },
     {
+        "description" : "placing robots in valid and invalid positions to check if AutoRef respects flipped position restrictions",
+        "timing" : {
+            "time" : [1.0,44.0],
+            "clock_type" : "Simulated",
+            "state" : "READY",
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "2nd Half: Ball is placed far from the field during all READY phase",
+                "target" : "BALL",
+                "position" : [100, 100, 0.08]
+            }
+        ]
+    },
+    {
         "description" : "Checking if state changes to SET",
         "timing" : {
             "time" : 47,
@@ -276,6 +316,11 @@
                 "name" : "Blue 2 in the opponent's field -> Penalty",
                 "target" : "BLUE_PLAYER_2",
                 "penalty": 34
+            },
+            {
+                "name" : "2nd Half: Ball is placed at center of the field during start",
+                "target" : "BALL",
+                "position" : [0, 0, 0.08]
             }
         ]
     },


### PR DESCRIPTION
Fixes #216

From logs of games, it seems that the what was expected to be dead code was
still used with the following side effect: ball was not respawned at an
appropriate location.

Additionally, the ball is now moved away from the field before kick-off.

The test for `second half` now tests for ball position as well.

It does not impact the results on the other automated tests and pass the new ones.