### PR TITLE
Fix reset of motor commands after unpenalization in case when no velo…

### DIFF
--- a/projects/samples/contests/robocup/controllers/player/player.cpp
+++ b/projects/samples/contests/robocup/controllers/player/player.cpp
@@ -389,9 +389,10 @@ public:
     return motor_command;
   }
 
-  void stopMotors() const {
+  void stopMotors() {
     for (size_t i = 0; i != motor_commands.size(); i++) {
       webots::Motor *motor = motor_commands[i]->motor;
+      velocities_to_resume[motor] = motor->getVelocity();
       motor->setVelocity(0);
       if (motor->getType() == webots::Motor::ROTATIONAL)
         motor->setTorque(0);
@@ -402,6 +403,7 @@ public:
   void resumeMotors() {
     for (size_t i = 0; i != motor_commands.size(); i++) {
       webots::Motor *motor = motor_commands[i]->motor;
+      motor->setVelocity(velocities_to_resume[motor]);
       if (!isnan(motor_commands[i]->position))
         motor->setPosition(motor_commands[i]->position);
       if (!isnan(motor_commands[i]->velocity))
@@ -783,6 +785,8 @@ private:
   std::vector<MotorCommand *> motor_commands;
   uint32_t controller_time;
   std::map<webots::Device *, uint32_t> start_sensoring_time;
+  std::map<webots::Motor *, double> velocities_to_resume;
+  
   char *recv_buffer;
   int recv_index;
   int recv_size;


### PR DESCRIPTION
Tests shows that previous patch fixes the velocities reset problem only in case that velocities were set once (at startup, etc). In case there is no velocity commands setted at all - resumeMotors fails to resume a robot (it stays freezed again).
This approach using an std::map to save current velocity state of a motor at penalization and resume them afterwards works in my more precise tests using no velocity commanding at all.