### PR TITLE
Penalty shootout updates based on vote from June 14th

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts_penalized/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/penalty_shootouts_penalized/test_scenario.json
@@ -110,20 +110,33 @@
     },
     {
         "timing" : {
+            "time" : 42,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "T1: Goalkeeper moves before ball is touched -> penalized",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 34
+            }
+        ]
+    },
+    {
+        "timing" : {
             "time" : 46,
             "clock_type" : "Simulated",
             "state" : "PLAYING"
         },
         "tests" : [
             {
-                "name" : "T1: kicker who falls for too long is penalized",
-                "target" : "BLUE_PLAYER_1",
-                "penalty" : 34
+                "name" : "T1: kicker who falls for too long -> end of trial",
+                "state" : "SET"
             },
             {
-                "name" : "T1: Goalkeeper moves before ball is touched -> penalized",
-                "target" : "RED_PLAYER_1",
-                "penalty" : 34
+                "name" : "T1: kicker who falls for too long -> no penalty",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
             }
         ]
     },


### PR DESCRIPTION
Those changes are:

- Disabling the ball_holding rule for penalty shootouts
- Changing the consequences of foul during penalty-shootouts
  - FreeKick cannot occur anymore
  - If goalkeeper commits a foul, it receives a removal penalty (duration change
    should be on the GameController side)
  - If penalty kicker commits a foul, the trial is ended.
- Goalkeeper are now allowed to stand behind their goal line during penalty
  shootouts
  
  Status of automated tests: Fully passing (after adapting test `penalty_shootouts_penalized`)