### PR TITLE
Fixing knockout and adding a dedicated test scenario

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -566,6 +566,8 @@ def game_controller_send(message):
         elif (message[:6] == 'SCORE:' or
               message == 'DROPPEDBALL'):
             game.wait_for_state = 'FINISHED' if game.penalty_shootout else 'READY'
+        elif message[6:] == "PENALTY-SHOOTOUT":
+            game.wait_for_state = 'INITIAL'
     if ':' in message:
         msg_start = message.split(':', 1)[0]
         if msg_start in GAME_INTERRUPTIONS:
@@ -1943,6 +1945,7 @@ def stop_penalty_shootout():
 def next_penalty_shootout():
     game.penalty_shootout_count += 1
     if not game.penalty_shootout_goal and game.state.game_state[:8] != "FINISHED":
+        info("Sending state finish to end current_penalty_shootout")
         game_controller_send('STATE:FINISH')
     game.penalty_shootout_goal = False
     if stop_penalty_shootout():
@@ -2421,6 +2424,7 @@ game.interruption_team = None
 game.interruption_seconds = None
 game.dropped_ball = False
 game.overtime = False
+game.finished_overtime = False
 game.ready_countdown = 0  # simulated time countdown before ready state (used in kick-off after goal and dropped ball)
 game.play_countdown = 0
 game.in_play = None
@@ -2631,6 +2635,7 @@ try:
                             game.overtime = True
                         else:
                             info('End of knockout second half.')
+                            game.finished_overtime = True
                     else:
                         error(f'Unsupported game type: {game.type}.', fatal=True)
             if (game.interruption_countdown == 0 and game.ready_countdown == 0 and
@@ -2771,19 +2776,22 @@ try:
             elif game.state.first_half:
                 info("Received state FINISHED: end of first half")
                 game.ready_real_time = None
-            elif game.type == 'KNOCKOUT' and game.overtime and game.state.teams[0].score == game.state.teams[1].score:
+            elif game.type == 'KNOCKOUT':
                 if game.ready_real_time is None:
-                    info('Beginning of the knockout first half.')
-                    game_controller_send('STATE:OVERTIME-FIRST-HALF')
-                    info(f'Going to READY in {HALF_TIME_BREAK_REAL_TIME_DURATION} seconds (real-time)')
-                    game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
-            elif game.type == 'KNOCKOUT' and game.state.teams[0].score == game.state.teams[1].score:
-                if game.ready_real_Time is None:
-                    info('Beginning of penalty shout-out.')
-                    game_controller_send('STATE:PENALTY-SHOOTOUT')
-                    game.penalty_shootout = True
-                    info(f'Going to READY in {HALF_TIME_BREAK_REAL_TIME_DURATION} seconds (real-time)')
-                    game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
+                    if game.state.teams[0].score != game.state.teams[1].score:
+                        game.over = True
+                        break
+                    elif game.finished_overtime:
+                        info('Beginning of penalty shout-out.')
+                        game_controller_send('STATE:PENALTY-SHOOTOUT')
+                        game.penalty_shootout = True
+                        info(f'Going to SET in {HALF_TIME_BREAK_REAL_TIME_DURATION} seconds (real-time)')
+                        game.set_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
+                    elif game.overtime:
+                        info('Beginning of the knockout first half.')
+                        game_controller_send('STATE:OVERTIME-FIRST-HALF')
+                        info(f'Going to READY in {HALF_TIME_BREAK_REAL_TIME_DURATION} seconds (real-time)')
+                        game.ready_real_time = time.time() + HALF_TIME_BREAK_REAL_TIME_DURATION
             else:
                 game.over = True
                 break

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/README.md
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/README.md
@@ -1,0 +1,15 @@
+# Knockout
+
+## What is tested
+
+- Kickoff properly changes between two half times
+- Knockout games have a valid procedure in case of draw and are not crashing:
+  1. Regular time
+  2. Extended time
+  3. Penalty shootout
+  4. Extended penalty shootout
+
+## Setup
+
+- Team RED has kickoff
+

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/game.json
@@ -1,0 +1,44 @@
+{
+  "type": "KNOCKOUT",
+  "game_controller_extra_args" : ["--halftimeduration", "20", "--overtimeduration", "20"],
+  "class": "KID",
+  "host": "192.168.1.133",
+  "side_left": "blue",
+  "kickoff": "red",
+  "minimum_real_time_factor" : 0,
+  "supervisor": "test_supervisor",
+  "red": {
+    "id": 5,
+    "config": "tests/game_phases/knockout/team_1.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.21",
+      "192.168.123.22",
+      "192.168.123.23",
+      "192.168.123.24"
+    ],
+    "ports": [
+      10001,
+      10002,
+      10003,
+      10004
+    ]
+  },
+  "blue": {
+    "id": 7,
+    "config": "tests/game_phases/knockout/team_2.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.41",
+      "192.168.123.42",
+      "192.168.123.43",
+      "192.168.123.44"
+    ],
+    "ports": [
+      10021,
+      10022,
+      10023,
+      10024
+    ]
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/team_1.json
@@ -1,0 +1,24 @@
+{
+  "name": "Funny Dingos",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2.6, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/team_2.json
@@ -1,0 +1,24 @@
+{
+  "name": "Agile Lynxes",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2.6, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_phases/knockout/test_scenario.json
@@ -1,0 +1,241 @@
+[
+    {
+        "timing" : {
+            "time" : 2,
+            "clock_type" : "Simulated",
+            "state" : "INITIAL"
+        },
+        "tests" : [
+            {
+                "name" : "1st HT: kickoff RED",
+                "kickoff" : "red"
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 47,
+            "clock_type" : "Simulated",
+            "state" : "READY"
+        },
+        "tests" : [
+            {
+                "name" : "1st HT: transition to SET",
+                "state" : "SET",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 6,
+            "clock_type" : "Simulated",
+            "state" : "SET"
+        },
+        "tests" : [
+            {
+                "name" : "1st HT: transition to PLAYING",
+                "state" : "PLAYING",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 25,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "1st HT: transition to 2nd HT INITIAL",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 47,
+            "clock_type" : "Simulated",
+            "state" : "READY",
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "2nd HT: transition to SET",
+                "state" : "SET",
+                "critical" : true
+            },
+            {
+                "name" : "1st HT: kickoff BLUE",
+                "kickoff" : "blue"
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 6,
+            "clock_type" : "Simulated",
+            "state" : "SET",
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "2nd HT: transition to PLAYING",
+                "state" : "PLAYING",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 22,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING",
+            "state_count" : 2
+        },
+        "tests" : [
+            {
+                "name" : "2nd HT: transition to INITIAL in 1st EHT",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 47,
+            "clock_type" : "Simulated",
+            "state" : "READY",
+            "state_count" : 3
+        },
+        "tests" : [
+            {
+                "name" : "1st EHT: transition to SET",
+                "state" : "SET",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 7,
+            "clock_type" : "Simulated",
+            "state" : "SET",
+            "state_count" : 3
+        },
+        "tests" : [
+            {
+                "name" : "1st EHT: transition to PLAYING",
+                "state" : "PLAYING",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 22,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING",
+            "state_count" : 3
+        },
+        "tests" : [
+            {
+                "name" : "1st EHT: transition to 2nd EHT",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 47,
+            "clock_type" : "Simulated",
+            "state" : "READY",
+            "state_count" : 4
+        },
+        "tests" : [
+            {
+                "name" : "2nd EHT: transition to SET",
+                "state" : "SET",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 7,
+            "clock_type" : "Simulated",
+            "state" : "SET",
+            "state_count" : 4
+        },
+        "tests" : [
+            {
+                "name" : "2nd EHT: transition to PLAYING",
+                "state" : "PLAYING",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 22,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING",
+            "state_count" : 4
+        },
+        "tests" : [
+            {
+                "name" : "2nd EHT: transition to penalty shootout",
+                "state" : "INITIAL",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : [1,14],
+            "clock_type" : "Simulated",
+            "state" : "SET",
+            "state_count" : 5
+        },
+        "tests" : [
+            {
+                "name" : "P1: stays in SET for 15 secs",
+                "state" : "SET",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 17,
+            "clock_type" : "Simulated",
+            "state" : "SET",
+            "state_count" : 5
+        },
+        "tests" : [
+            {
+                "name" : "P1: transition SET-> PLAYING",
+                "state" : "PLAYING",
+                "critical" : true
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 65,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING",
+            "state_count" : 5
+        },
+        "tests" : [
+            {
+                "name" : "P1: transition from PLAYING to P2 in SET",
+                "state" : "SET",
+                "critical" : true
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Solving this mode required:
- Using update GameController: https://github.com/RoboCup-Humanoid-TC/GameController/pull/166
- Adding a flag `finished_overtime` and changing how the end of the second extended half-time
  is treated.
  - Note that the code changed was previously unreachable since it contained
    usage of a member that was never defined `game.ready_real_Time` with a
    capital `T`