### PR TITLE
Allowing goals to be scored directly from FREEKICK and PENALTYKICK

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -2017,6 +2017,7 @@ def interruption(interruption_type, team=None, location=None, is_goalkeeper_ball
                     ball_reset_location[0] *= -1
         else:
             interruption_type = 'DIRECT_FREEKICK'
+        game.can_score = interruption_type != 'INDIRECT_FREEKICK'
     game.in_play = None
     game.can_score_own = False
     game.ball_set_kick = True
@@ -2567,7 +2568,7 @@ try:
                         game.ball_left_circle = time_count
                         info('The ball has left the center circle after kick-off.')
 
-                ball_touched_by_opponent = game.ball_last_touch_team != game.ball_must_kick_team
+                ball_touched_by_opponent = game.ball_last_touch_team and (game.ball_last_touch_team != game.ball_must_kick_team)
                 ball_touched_by_teammate = (game.kicking_player_number is not None and
                                             game.ball_last_touch_player_number != game.kicking_player_number)
                 ball_touched_in_play = game.in_play is not None and game.in_play < game.ball_last_touch_time

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/README.md
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/README.md
@@ -1,0 +1,14 @@
+# Scoring a goal from free kick
+
+## What is tested
+
+- When a robot scores a goal directly from a free kick it is considered as valid
+
+## Setup
+
+- A free kick is awarded to team BLUE by multi ball holding from team red
+
+## Description
+
+1. BLUE 1 kicks the ball directly into the opponent goal.
+2. A goal is awarded to team BLUE and a kick off is awarded to team RED.

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/game.json
@@ -1,0 +1,43 @@
+{
+  "type": "NORMAL",
+  "class": "KID",
+  "host": "192.168.1.133",
+  "minimum_real_time_factor": 0,
+  "side_left": "red",
+  "kickoff": "red",
+  "supervisor": "test_supervisor",
+  "red": {
+    "id": 1,
+    "config": "tests/game_interruptions/free_kick/scoring/goal/team_1.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.21",
+      "192.168.123.22",
+      "192.168.123.23",
+      "192.168.123.24"
+    ],
+    "ports": [
+      10001,
+      10002,
+      10003,
+      10004
+    ]
+  },
+  "blue": {
+    "id": 8,
+    "config": "tests/game_interruptions/free_kick/scoring/goal/team_2.json",
+    "hosts": [
+      "127.0.0.1",
+      "192.168.123.41",
+      "192.168.123.42",
+      "192.168.123.43",
+      "192.168.123.44"
+    ],
+    "ports": [
+      10021,
+      10022,
+      10023,
+      10024
+    ]
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/team_1.json
@@ -1,0 +1,43 @@
+{
+  "name": "Funny Dingos",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    },
+    "2": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/team_2.json
@@ -1,0 +1,24 @@
+{
+  "name": "Agile Lynxes",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-3.5, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.5, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/game_interruptions/free_kick/scoring/goal/test_scenario.json
@@ -1,0 +1,158 @@
+[
+    {
+        "description" : "Placing robots inside their own field",
+        "timing" : {
+            "time" : 5.0,
+            "clock_type" : "Simulated",
+            "state" : "READY"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-2, -2, 0.24],
+                "orientation" : [0, 0, 1, 0]
+            },
+            {
+                "target" : "RED_PLAYER_2",
+                "position" : [-2, 2, 0.24],
+                "orientation" : [0, 0, 1, 0]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [2, -2, 0.24],
+                "orientation" : [0, 0, 1, 3.14]
+            }
+        ]
+    },
+    {
+        "description" : "Sanity check, robots not penalized",
+        "timing" : {
+            "time" : 4.0,
+            "clock_type" : "Simulated",
+            "state" : "SET"
+        },
+        "tests" : [
+            {
+                "name" : "Sanity check: Red 1 is not penalized",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "Sanity check: Red 2 is not penalized",
+                "target" : "RED_PLAYER_2",
+                "penalty" : 0
+            },
+            {
+                "name" : "Sanity check: Blue 1 is not penalized",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
+            }
+        ]
+    },
+    {
+        "description" : "preparing the ball holding by red after ball is in play",
+        "timing" : {
+            "time" : 12,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-0.5, -0.4, 0.24]
+            },
+            {
+                "target" : "RED_PLAYER_2",
+                "position" : [-0.5, 0.4, 0.24]
+            },
+            {
+                "target" : "BALL",
+                "position" : [-0.5, 0, 0.08]
+            }
+        ]
+    },
+    {
+        "description" : "Testing Setup + moving players away",
+        "timing" : {
+            "time" : 14,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "SETUP ends with free kick for team blue",
+                "secondary_state" : "DIRECT_FREEKICK",
+                "secondary_team_id" : 8,
+                "critical" : true
+            }
+        ],
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-0.5, -0.9, 0.24]
+            },
+            {
+                "target" : "RED_PLAYER_2",
+                "position" : [-0.5, 0.9, 0.24]
+            }
+        ]
+    },
+    {
+        "description" : "Setup phases are finished: place kicker blue apply ball contact",
+        "timing" : {
+            "time" : 7,
+            "clock_type" : "Simulated",
+            "secondary_state" : "DIRECT_FREEKICK",
+            "phase" : 1
+        },
+        "actions" : [
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [-0.2, 0, 0.24]
+            },
+            {
+                "target" : "BALL",
+                "force" : [10, 0, 0]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 8,
+            "clock_type" : "Simulated",
+            "secondary_state" : "DIRECT_FREEKICK",
+            "phase" : 1
+        },
+        "actions" : [
+            {
+                "target" : "BALL",
+                "force" : [-130, 0, 0]
+            }
+        ]
+    },
+    {
+        "timing" : {
+            "time" : 15,
+            "clock_type" : "Simulated",
+            "secondary_state" : "DIRECT_FREEKICK",
+            "phase" : 1
+        },
+        "tests" : [
+            {
+                "name" : "Kickoff for red",
+                "state" : "READY",
+                "kick_off_team" : 1
+            },
+            {
+                "name" : "Goal is scored for team BLUE",
+                "target" : "BLUE",
+                "score" : 1
+            },
+            {
+                "name" : "No goal for team RED",
+                "target" : "RED",
+                "score" : 0
+            }
+        ]
+    }
+]


### PR DESCRIPTION
The previous implementation did not properly set the `game.can_score` variable.

Adding a test scenario to check that the fix works properly.

Initially, the scenario was passing in both cases, which was surprising. After a
more thorough investigation, the source was that `ball_touched_by_opponent` was
always considered as True when `game.ball_last_touch_team` was `None`.

With the current version, test is failing if we don't set the can_score
properly.

All tests are passing.