### PR TITLE
Fix duplicated background node

### DIFF
--- a/projects/samples/contests/robocup/worlds/robocup.wbt
+++ b/projects/samples/contests/robocup/worlds/robocup.wbt
@@ -37,12 +37,6 @@ Viewpoint {
   orientation 0.8938498316033444 -0.2697810913064417 -0.35812098698090605 1.4005817359063022
   position -8.658964597484593 -10.448717096347492 4.001015029323764
 }
-TexturedBackground {
-  texture "stadium_dry"
-}
-TexturedBackgroundLight {
-  texture "stadium_dry"
-}
 Robot {
   supervisor TRUE
   controller "referee"


### PR DESCRIPTION
**Description**
Removes Backround and Background Light as they are now set by the autoref. This avoids the an error where only the default background is used.

**Related Issues**
#285 
#287 

**Screenshots**
![image](https://user-images.githubusercontent.com/15075613/148107613-546b4d47-6471-42d9-a15f-53dbaaa1c53e.png)