### PR TITLE
Fix display

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/display.py
+++ b/projects/samples/contests/robocup/controllers/referee/display.py
@@ -99,7 +99,7 @@ class Display:
             right_color = self.blackboard.config.RED_COLOR
 
         strings = SimpleNamespace()
-        strings.foreground = ' ' + format_time(self.blackboard.game.state.secondary_seconds_remaining) + '  ' \
+        strings.foreground = format_time(self.blackboard.game.state.secondary_seconds_remaining) + '  ' \
             if self.blackboard.game.state.secondary_seconds_remaining > 0 else ' ' * 8
         strings.background = ' ' * 7
         strings.warning = strings.background
@@ -108,8 +108,8 @@ class Display:
         strings.white = '█' * 7
         self.update_team_details_display(left_team, left, strings)
         strings.left_background = strings.background
-        strings.background = ' ' * 28
-        space = 21 - len(left_team.players) * 3
+        strings.background = ' ' * 26
+        space = 19 - len(left_team.players) * 3
         strings.white += '█' * space
         strings.warning += ' ' * space
         strings.yellow_card += ' ' * space
@@ -119,15 +119,9 @@ class Display:
         strings.right_background = strings.background
         del strings.background
         space = 12 - 3 * len(right_team.players)
-        strings.white += '█' * (22 + space)
+        strings.white += '█' * (24 + space)
         strings.secondary_state = ' ' * 41 + self.blackboard.game.state.secondary_state[6:]
-        sr = self.blackboard.config.IN_PLAY_TIMEOUT - self.blackboard.game.interruption_seconds \
-            + self.blackboard.game.state.seconds_remaining \
-            if self.blackboard.game.interruption_seconds is not None else 0
-        if sr > 0:
-            strings.secondary_state += ' ' + format_time(sr)
-        if (self.blackboard.game.state.secondary_state[6:] != 'NORMAL' or
-                self.blackboard.game.state.secondary_state_info[1] != 0):
+        if self.blackboard.game.state.secondary_state[6:] != 'NORMAL':
             strings.secondary_state += ' [' + str(self.blackboard.game.state.secondary_state_info[1]) + ']'
         if self.blackboard.game.interruption_team is not None:  # interruption
             secondary_state_color = self.blackboard.config.RED_COLOR \

--- a/projects/samples/contests/robocup/controllers/referee/display.py
+++ b/projects/samples/contests/robocup/controllers/referee/display.py
@@ -160,7 +160,7 @@ class Display:
                                             self.blackboard.config.WHITE_COLOR, 0.2, self.font)
         self.update_score_display()
 
-    def setup_display(self):
+    def update(self):
         self.update_team_display()
         self.update_time_display()
         self.update_state_display()

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -126,7 +126,7 @@ class Referee:
             if 'GAME_CONTROLLER_UDP_FILTER' in os.environ else None
 
         self.setup()
-        self.display.setup_display()
+        self.display.update()
 
         self.status_update_last_real_time = None
         self.status_update_last_sim_time = None
@@ -365,12 +365,12 @@ class Referee:
                     if self.game.in_play is None:
                         self.logger.info('Ball in play, can be touched by any player (10 seconds elapsed).')
                         self.game.ball_in_play(self.sim_time.get_ms())
-            self.display.update_time_display()
+            self.display.update()
         red = 0 if self.game.state.teams[0].team_color == 'RED' else 1
         blue = 1 if red == 0 else 0
         if previous_red_score != self.game.state.teams[red].score or \
                 previous_blue_score != self.game.state.teams[blue].score:
-            self.display.update_score_display()
+            self.display.update()
         # print(self.game.state.game_state)
         secondary_state = self.game.state.secondary_state
         secondary_state_info = self.game.state.secondary_state_info
@@ -406,7 +406,7 @@ class Referee:
                 previous_sec_state != new_sec_state or previous_sec_phase != new_sec_phase or \
                 previous_secondary_seconds_remaining != self.game.state.secondary_seconds_remaining or \
                 self.game.state.seconds_remaining <= 0:
-            self.display.update_state_display()
+            self.display.update()
 
     def game_controller_send(self, message):
         if message[:6] == 'STATE:' or message[:6] == 'SCORE:' or message == 'DROPPEDBALL':
@@ -1471,7 +1471,7 @@ class Referee:
         for team in [self.red_team, self.blue_team]:
             for number, player in team.players.items():
                 self.flip_poses(player)
-        self.display.update_team_display()
+        self.display.update()
 
     def reset_player(self, color, number, pose, custom_t=None, custom_r=None):
         team = self.red_team if color == 'red' else self.blue_team
@@ -2030,7 +2030,7 @@ class Referee:
             self.clean_exit()
 
         try:
-            self.display.update_state_display()
+            self.display.update()
             self.logger.info(f'Game type is {self.game.type}.')
             self.logger.info(f'Red team is "{self.red_team.name}", '
                              f'playing on {"left" if self.game.side_left == self.game.red.id else "right"} side.')
@@ -2174,7 +2174,7 @@ class Referee:
                             if self.game.penalty_shootout_time_to_reach_goal_area[c] is None:
                                 self.game.penalty_shootout_time_to_reach_goal_area[c] = 60 - self.game.state.seconds_remaining
                 if self.previous_seconds_remaining != self.game.state.seconds_remaining:
-                    self.display.update_state_display()
+                    self.display.update()
                     self.previous_seconds_remaining = self.game.state.seconds_remaining
                     # TODO find out why GC can send negative 'seconds_remaining' when secondary state is penaltykick
                     if self.game.state.game_state != "STATE_FINISHED" and self.game.state.seconds_remaining <= 0 and \


### PR DESCRIPTION
**Description**
This PR fixes the display on the upper left side of the screen.

- The indentation of the values is fixed
- The broken NORMAL counter is removed
- The order in which all the elements are drawn is fixed by drawing all elements in the right order on every update. While this is a bit more ineficcient it solves many combinations in which the calls of the ref result in a wrong order of the different layers.

**Related Issues**
This pull-request fixes issue #277

**Screenshots**
Previously:
![image](https://user-images.githubusercontent.com/15075613/148142076-a658b8b1-f728-4890-a402-37972507c113.png)

Now:
![image](https://user-images.githubusercontent.com/15075613/148142154-7183ff04-d317-4836-9aa1-a8105bdca951.png)
![image](https://user-images.githubusercontent.com/15075613/148142243-017a336c-bced-4e70-8dca-f94c8ad2123b.png)


The PR was tested locally.