### PR TITLE
[patch] add missing python3 requirement

### DIFF
--- a/projects/samples/contests/robocup/controllers/model_verifier/README.md
+++ b/projects/samples/contests/robocup/controllers/model_verifier/README.md
@@ -10,9 +10,11 @@ although it did not trigger errors nor warning during the analysis.
 
 Additionally to `Webots`, you will need the python modules listed in `requirements.txt`.
 
-Generating a `pdf` report requires the `pandoc` tool:
+`pip3 install -r requirements.txt`
 
-`sudo apt install pandoc`
+Generating a `pdf` report requires the `pandoc` and `texlive` tools:
+
+`sudo apt install pandoc texlive`
 
 ## Robot inspection
 

--- a/projects/samples/contests/robocup/controllers/model_verifier/requirements.txt
+++ b/projects/samples/contests/robocup/controllers/model_verifier/requirements.txt
@@ -3,3 +3,4 @@ pandas
 tabulate
 transforms3d
 trimesh
+pyglet

--- a/projects/samples/contests/robocup/controllers/referee/requirements.txt
+++ b/projects/samples/contests/robocup/controllers/referee/requirements.txt
@@ -2,3 +2,4 @@ construct
 numpy
 transforms3d
 scipy
+pyyaml


### PR DESCRIPTION
- model_verifier.py dependency to `pyglet` was missing.
- Add extra line to explain how to install the requirements.txt file
- Extra hint to install `texlive`, otherwise pdf generation will fail because `pdflatex` is missing
- referee.py dependency to `pyyaml` was missing