### PR TITLE
change ball lighting to pbr

### DIFF
--- a/projects/samples/contests/robocup/protos/RobocupTexturedSoccerBall.proto
+++ b/projects/samples/contests/robocup/protos/RobocupTexturedSoccerBall.proto
@@ -27,14 +27,11 @@ PROTO RobocupTexturedSoccerBall [
     scale %<= scale >% %<= scale >% %<= scale >%
     children [
       DEF BALL_SHAPE Shape {
-        appearance Appearance {
-          material Material {
-            ambientIntensity 0.4
-            diffuseColor IS color
-            shininess 0.8
-            specularColor 1 1 1
-          }
-          texture ImageTexture{
+        appearance PBRAppearance {
+          baseColor 0.8 0.8 0.8
+          roughness 0.5
+          metalness 0.1
+          baseColorMap ImageTexture{
 			      url [ %<= '"textures/' + fields.texture.value + '.jpg"'>% ]
           }
         }


### PR DESCRIPTION
**Description**
Previously ball lighting was "incorrect" because it was only using the Apperance node and not the PBRAppearance node of webots.

**Screenshots**
Before:
![Screenshot from 2022-02-01 13-34-32](https://user-images.githubusercontent.com/31923619/151972634-a4977eac-122a-47d5-b575-916da7c000ff.png)
After:
![Screenshot from 2022-02-01 13-32-46](https://user-images.githubusercontent.com/31923619/151972646-59422944-fe36-413d-ab9c-af56d0b3d213.png)

