### PR TITLE
Fixes a game crash

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1380,8 +1380,7 @@ class Referee:
         2. If team with game_interruption does ball holding game interruption continues
         """
         # Warnings only applies in step 1 and 2 of game interruptions
-        team_id = self.game.red.id if team.color == 'red' else self.game.blue.id
-        opponent = team_id != self.game.interruption_team
+        opponent = team != self.game.interruption_team
         if opponent:
             self.game.in_play = None
             self.game.ball_set_kick = True

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -1349,15 +1349,12 @@ class Referee:
         """
         return self.is_game_interruption() and self.game.state.secondary_state_info[1] == 0
 
-    def game_interruption_touched(self, team, number=0):
+    def game_interruption_touched(self, team, number):
         """
-        Applies the associated actions for when a robot touches the ball
-        or a team (number=0) commits a ball holding during step 1 and 2 of game interruptions
+        Applies the associated actions for when a robot touches the ball during step 1 and 2 of game interruptions
 
         1. If opponent touches the ball, robot receives a WARN and RETAKE is sent
         2. If team with game_interruption touched the ball, player receives a WARN and ABORT is sent
-        3. If the opponent team performs a ball holding, a RETAKE is sent
-        4. If the team with game_interruption persoms a ball holding, a ABORD is sent
         """
         # Warnings only applies in step 1 and 2 of game interruptions
         team_id = self.game.red.id if team.color == 'red' else self.game.blue.id
@@ -1373,8 +1370,25 @@ class Referee:
             self.game.in_play = self.sim_time.get_ms()
             self.logger.info(f"Ball touched before execute, aborting {GAME_INTERRUPTIONS[self.game.interruption]}")
             self.game_controller_send(f'{self.game.interruption}:{self.game.interruption_team}:ABORT')
-        if number > 0:
-            self.game_controller_send(f'CARD:{team_id}:{number}:WARN')
+        self.game_controller_send(f'CARD:{team_id}:{number}:WARN')
+
+    def game_interruption_ball_holding(self, team):
+        """
+        Applies the associated actions for when a robot does ball holding duing an interruption
+
+        1. If opponent commits ball holding, RETAKE is sent
+        2. If team with game_interruption does ball holding game interruption continues
+        """
+        # Warnings only applies in step 1 and 2 of game interruptions
+        team_id = self.game.red.id if team.color == 'red' else self.game.blue.id
+        opponent = team_id != self.game.interruption_team
+        if opponent:
+            self.game.in_play = None
+            self.game.ball_set_kick = True
+            self.game.interruption_countdown = self.config.SIMULATED_TIME_INTERRUPTION_PHASE_0
+            self.logger.info(f"Ball holding by opponent team, retaking {GAME_INTERRUPTIONS[self.game.interruption]}")
+            self.logger.info(f"Reset interruption_countdown to {self.game.interruption_countdown}")
+            self.game_controller_send(f'{self.game.interruption}:{self.game.interruption_team}:RETAKE')
 
     def get_first_available_spot(self, team_color, number, reentry_pos):
         """Return the first available spot to enter on one side of the field given the reentry_pos"""
@@ -2423,12 +2437,12 @@ class Referee:
                     ball_holding = self.check_ball_holding()       # check for ball holding fouls
                     if ball_holding:
                         if self.is_game_interruption():
-                            self.game_interruption_touched(ball_holding)
+                            self.game_interruption_ball_holding(ball_holding)
                         else:
                             self.interruption('FREEKICK', ball_holding, self.game.ball_position)
                 ball_handling = self.check_ball_handling()  # return team id if ball handling is performed by goalkeeper
                 if ball_handling and not self.game.penalty_shootout:
-                    self.interruption('FREEKICK', ball_handling, self.game.ball_position, is_goalkeeper_ball_manipulation=True)
+                    self.interruption('FREEKICK', ball_handling, self.game.ball_position, is_goalkeeper_ball_manipulation=True) # TODO check logic here 
             self.check_penalized_in_field()                    # check for penalized robots inside the field
             if self.game.state.game_state != 'STATE_INITIAL':  # send penalties if needed
                 self.send_penalties()

--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -2418,7 +2418,10 @@ class Referee:
                 if not self.game.penalty_shootout:
                     ball_holding = self.check_ball_holding()       # check for ball holding fouls
                     if ball_holding:
-                        self.interruption('FREEKICK', ball_holding, self.game.ball_position)
+                        if self.is_game_interruption():
+                            self.game_interruption_touched(ball_holding, 0)
+                        else:
+                            self.interruption('FREEKICK', ball_holding, self.game.ball_position)
                 ball_handling = self.check_ball_handling()  # return team id if ball handling is performed by goalkeeper
                 if ball_handling and not self.game.penalty_shootout:
                     self.interruption('FREEKICK', ball_handling, self.game.ball_position, is_goalkeeper_ball_manipulation=True)


### PR DESCRIPTION
In some cases, the game gets terminated in the middle of the game and it seems to be caused by the AutoReferee trying to make a call which is returned with an ILLEGAL response from the GameController. Looking at the logs, the AutoReferee seems to try to award a Direct Free Kick to team A while there is an ongoing Free Kick for team B, which is not possible according to our game rules (the current free kick situation needs to be resolved before a new free kick or penalty kick can be awarded).

Here are three game logs that all have the termination of the game after an ILLEGAL call by the AutoRef:
[EDIT Maike: taken out the logs as they are no public resource]

<details>
<summary>The interesting lines from the log files are:</summary>

```
[9788.661|0985.240] Info: GI placing ball to [3.5609966246876104, -0.7867616154045358, 0]
[9788.661|0985.240] Info: Reset of penalized robots
[9788.661|0985.240] Info: Penalizing fallen robots
[9788.661|0985.240] Info: Finding alternative locations
[9788.662|0985.240] Info: Testing alternative location: [ 3.06099662 -0.78676162  0.        ]
[9788.662|0985.240] Info: Testing alternative location: [ 3.56099662 -0.28676162  0.        ]
[9788.662|0985.240] Info: Set alternative location to: [ 3.56099662 -0.28676162  0.        ]
[9788.662|0985.240] Info: Ball respawned at 3.5609966246876104 -0.2867616154045358 0.07.
[9788.662|0985.240] Info: Waiting for secondary state: DIRECT_FREEKICK:1
[9788.662|0985.240] Info: Sending 123441:DIRECT_FREEKICK:11:READY to GameController.
[9788.662|0985.240] Info: Waiting for GameController to answer to 123441:DIRECT_FREEKICK:11:READY.
[9788.862|0985.240] Info: Waiting for GameController to answer to 123441:DIRECT_FREEKICK:11:READY.
[9789.850|0985.240] Info: New secondary state received from GameController: STATE_DIRECT_FREEKICK, phase 1.
[9789.850|0985.240] Info: State has succesfully changed to STATE_DIRECT_FREEKICK:1
[9789.949|0985.248] Info: [3.5609966246876104, -0.7867616154045358, 0] [3.5609966246876104, -0.2867616154045358, 0.07]
[9789.949|0985.248] Info: Ball in play, can be touched by any player (moved by 50.00 cm).
[9794.119|0985.664] Info: STATUS: Avg speed factor: 0.092 (over last 20.02 seconds)
[9794.119|0985.664] Info: STATUS: state: STATE_PLAYING, remaining time: 477
[9814.171|0987.712] Info: STATUS: Avg speed factor: 0.102 (over last 20.05 seconds)
[9814.171|0987.712] Info: STATUS: state: STATE_PLAYING, remaining time: 477
[9828.015|0989.136] Info: Red team (['1', '2']) is holding the ball.
[9832.826|0989.632] Info: Red team has held the ball for too long.
[9832.826|0989.632] Info: Interruption countdown set to 625
[9832.826|0989.632] Info: Ball not in play, will be kicked by a player from the blue team.
[9832.826|0989.632] Info: Penalty kick awarded to blue team.
[9832.826|0989.632] Info: Waiting for secondary state: PENALTYKICK:0
[9832.826|0989.632] Info: Sending 123993:PENALTYKICK:4 to GameController.
[9832.826|0989.632] Info: Waiting for GameController to answer to 123993:PENALTYKICK:4.
[9833.026|0989.632] Info: Waiting for GameController to answer to 123993:PENALTYKICK:4.
[9833.227|0989.632] Error: Received illegal answer from GameController for message 123993:PENALTYKICK:4.
[9833.227|0989.632] Info: FINAL SCORE: 2-2
[9833.227|0989.632] Info: Terminating 'game_controller' process
[9833.227|0989.632] Info: Stopping animation recording
[9835.687|0989.632] Info: Exiting webots properly
```
</details>

The idea proposed in this fix is to consider that during a freekick game interruption, a ball holding should be considered like an illegal kick. Hence, if such a situation is detected, the same procedure as the illegal kick is called, except that there is no WARN message sent any the player as ball holding is a collective foul.