### PR TITLE
[fix] follow python coding guidelines

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee.py
+++ b/projects/samples/contests/robocup/controllers/referee/referee.py
@@ -2441,7 +2441,8 @@ class Referee:
                             self.interruption('FREEKICK', ball_holding, self.game.ball_position)
                 ball_handling = self.check_ball_handling()  # return team id if ball handling is performed by goalkeeper
                 if ball_handling and not self.game.penalty_shootout:
-                    self.interruption('FREEKICK', ball_handling, self.game.ball_position, is_goalkeeper_ball_manipulation=True) # TODO check logic here 
+                    # TODO check logic of the interruption
+                    self.interruption('FREEKICK', ball_handling, self.game.ball_position, is_goalkeeper_ball_manipulation=True)
             self.check_penalized_in_field()                    # check for penalized robots inside the field
             if self.game.state.game_state != 'STATE_INITIAL':  # send penalties if needed
                 self.send_penalties()


### PR DESCRIPTION
The CI was complaining about an extra white space at the end, and to
many characters in one single line. 🤷

>  /home/runner/work/webots/webots/projects/samples/contests/robocup/controllers/referee/referee.py:2444:128: E261: at least two spaces before inline comment
> /home/runner/work/webots/webots/projects/samples/contests/robocup/controllers/referee/referee.py:2444:129: E501: line too long (151 > 128 characters)
> /home/runner/work/webots/webots/projects/samples/contests/robocup/controllers/referee/referee.py:2444:152: W291: trailing whitespace