### PR TITLE
Penalizing robots colliding with the goal for extend periods of time

### DIFF
--- a/projects/samples/contests/robocup/controllers/referee/referee_config.yaml
+++ b/projects/samples/contests/robocup/controllers/referee/referee_config.yaml
@@ -1,4 +1,6 @@
 OUTSIDE_TURF_TIMEOUT: 20                 # a player outside the turf for more than 20 seconds gets a removal penalty
+GOAL_COLLISION_TIMEOUT: 30               # a player colliding with a goal for more than 30 seconds gets a removal penalty
+GOAL_COLLISION_RATIO: 0.5                # a player must be colliding with a goal for an average of more than 0.5 of the window time to commit a foul
 INVALID_GOALKEEPER_TIMEOUT: 1            # 1 second
 INACTIVE_GOALKEEPER_TIMEOUT: 20          # a goalkeeper is penalized if inactive for 20 seconds while the ball is in goal area
 INACTIVE_GOALKEEPER_DIST: 0.5            # if goalkeeper is farther than this distance it can't be inactive

--- a/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/README.md
+++ b/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/README.md
@@ -1,0 +1,55 @@
+# Goal collision
+
+There are different parts in this scenario:
+
+## What is tested
+
+- A player that touches the goal continuously during 10 seconds, but manages
+  to move away is not penalized
+- A player that touches the goal for more than 15 seconds without interruption
+  is penalized
+- A player that touches the goal for 10 seconds, manages to get away for a few
+  seconds and then touches the goal for 5 more seconds is penalized.
+
+## Setup and description
+
+This scenario involves three robots, with independent scenarios
+
+- RED 1: goalkeeper
+- RED 2: field player
+- BLUE 1: goalkeeper
+
+
+### A. RED 1
+
+- Setup:
+  - Once state reaches PLAYING, robot falls on the goal
+  - After 10 seconds it gets away from the post
+- Expectations:
+  - RED 1 is never penalized
+
+### B. RED 2
+
+- Setup:
+  - Once state reaches PLAYING, robot falls on the goal
+  - It stays stuck on the goal for 15 seconds
+- Expectations:
+  - RED 2 is penalized approximately 15 seconds after colliding with the goal
+
+### C. BLUE 1
+
+- Setup:
+  - Once state reaches PLAYING, robot falls on the goal
+  - It stays stuck on the goal for 10 seconds and then moves away
+  - 10 seconds later it falls on the goal again and does not move
+- Expectations:
+  - BLUE 1 stays unpenalized for approximately 25 seconds after first collision
+  - Finally, BLUE 1 receives a penalty
+
+## Implementation note
+
+Since robots get 'inactive' if they are not moving, it is required to reset the
+position of the robots multiple times to ensure the robot does not become
+inactive.
+In a 'real-world' scenario, this should not be a problem since robots will use
+their motors to move and therefore not be considered as inactive.

--- a/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/game.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/game.json
@@ -1,0 +1,41 @@
+{
+  "type": "NORMAL",
+  "class": "KID",
+  "side_left": "blue",
+  "kickoff": "red",
+  "supervisor": "test_supervisor",
+  "minimum_real_time_factor" : 0,
+  "host": "127.0.0.1",
+  "red": {
+    "id": 9,
+    "config": "tests/misc_fouls/inactive_goalie/team_1.json",
+    "hosts": [
+      "192.168.123.21",
+      "192.168.123.22",
+      "192.168.123.23",
+      "192.168.123.24"
+    ],
+    "ports": [
+      10001,
+      10002,
+      10003,
+      10004
+    ]
+  },
+  "blue": {
+    "id": 8,
+    "config": "tests/misc_fouls/inactive_goalie/team_2.json",
+    "hosts": [
+      "192.168.123.41",
+      "192.168.123.42",
+      "192.168.123.43",
+      "192.168.123.44"
+    ],
+    "ports": [
+      10021,
+      10022,
+      10023,
+      10024
+    ]
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/team_1.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/team_1.json
@@ -1,0 +1,43 @@
+{
+  "name": "Funny Dingos",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-4.0, -3.06, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [-0.57735, -0.57735, -0.57735, -2.0944]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    },
+    "2": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-4.0, 3.06, 0.24],
+        "rotation": [0, 0, 1, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [-0.57735, -0.57735, -0.57735, -2.0944]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/team_2.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/team_2.json
@@ -1,0 +1,24 @@
+{
+  "name": "Agile Lynxes",
+  "players": {
+    "1": {
+      "proto": "RobocupRobot",
+      "halfTimeStartingPose": {
+        "translation": [-4.7, -2.06, 0.24],
+        "rotation": [0, 0, 1, 0]
+      },
+      "reentryStartingPose": {
+        "translation": [-3, -3.11, 0.24],
+        "rotation": [0, 0, 1, 1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2, 0, 0.24],
+        "rotation": [-0.57735, -0.57735, -0.57735, -2.0944]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.24],
+        "rotation": [0, 0, 1, 0]
+      }
+    }
+  }
+}

--- a/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/test_scenario.json
+++ b/projects/samples/contests/robocup/controllers/referee/tests/misc_fouls/goal_collision/test_scenario.json
@@ -1,0 +1,161 @@
+[
+    {
+    "description" : "Moving robots before ready to avoid penalties",
+    "timing" : {
+        "time" : 8.0,
+            "clock_type" : "Simulated",
+            "state" : "READY"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [4.3,2.06,0.24],
+                "orientation" : [0,0,1,3.14]
+            },
+            {
+                "target" : "RED_PLAYER_2",
+                "position" : [1.0,2,0.24],
+                "orientation" : [0,0,1,3.14]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [-4.3,-2.06,0.24]
+            }
+        ]
+    },
+    {
+        "description" : "Set-up",
+        "timing" : {
+            "time" : 1.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+                "position" : [-4.4,1.39,0.23],
+                "orientation" : [-0.132,-0.0106,0.991,3.102]
+            },
+            {
+                "target" : "RED_PLAYER_2",
+                "position" : [-4.4,-1.39,0.23],
+                "orientation" : [-0.132,-0.0106,0.991,3.102]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [4.4,-1.35,0.24],
+                "orientation" : [0,1,0,0.26]
+            }
+        ]
+    },
+    {
+        "description" : "Initial checks",
+        "timing" : {
+            "time" : [1,16],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "A. Robots are not penalized for at least 15s (1)",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "B. Robots are not penalized for at least 15s (2)",
+                "target" : "RED_PLAYER_2",
+                "penalty" : 0
+            },
+            {
+                "name" : "C. Robots are not penalized for at least 15s (3)",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
+            }
+        ]
+    },
+    {
+        "description" : "RED 1 and BLUE 1 move away from goal",
+        "timing" : {
+            "time" : 11.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "RED_PLAYER_1",
+            "position" : [-4.5,1.1,0.24],
+            "orientation" : [0,0,1,3.14]
+            },
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [4.3,-1.35,0.24],
+                "orientation" : [0,0,1,3.14]
+            }
+        ]
+    },
+    {
+        "description" : "Only B gets penalized",
+        "timing" : {
+            "time" : [18,25],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "A. Interrupted contact -> no penalty(1)",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "B. 15 seconds continuous contact -> penalty",
+                "target" : "RED_PLAYER_2",
+                "penalty" : 34
+            },
+            {
+                "name" : "C. Interrupted contact -> no penalty(2)",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 0
+            }
+        ]
+    },
+    {
+        "description" : "BLUE 1 moves back to goal",
+        "timing" : {
+            "time" : 26.0,
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "actions" : [
+            {
+                "target" : "BLUE_PLAYER_1",
+                "position" : [4.4,-1.35,0.24],
+                "orientation" : [0,1,0,0.26]
+            }
+        ]
+    },
+    {
+        "description" : "Both B and C are penalized",
+        "timing" : {
+            "time" : [32,35],
+            "clock_type" : "Simulated",
+            "state" : "PLAYING"
+        },
+        "tests" : [
+            {
+                "name" : "A. No new contact -> no penalty",
+                "target" : "RED_PLAYER_1",
+                "penalty" : 0
+            },
+            {
+                "name" : "B. Resumed contact -> penalty",
+                "target" : "RED_PLAYER_2",
+                "penalty" : 34
+            },
+            {
+                "name" : "C. 15 seconds continuous contact -> penalty",
+                "target" : "BLUE_PLAYER_1",
+                "penalty" : 34
+            }
+        ]
+    }
+]


### PR DESCRIPTION
*Note: this is a new feature that should help to increase performances when robots are constantly running toward goalposts*

Store the information of contact with the goal in a 30 seconds buffer
and penalize robots if they spent more than 50% of the time touching
the goal.

A test scenario including 3 basic tests is implemented.

All tests including the new one are passing.
